### PR TITLE
fixed bugs for invalid psm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "quantms-rescoring"
 description = "quantms-rescoring: Python scripts and helpers for the quantMS workflow"
 readme = "README.md"
 license = "MIT"
-version = "0.0.2"
+version = "0.0.3"
 authors = [
     "Yasset Perez-Riverol <ypriverol@gmail.com>",
     "Dai Chengxin <chengxin2024@126.com>",

--- a/quantmsrescore/ms2rescore.py
+++ b/quantmsrescore/ms2rescore.py
@@ -72,8 +72,9 @@ class IDXMLReaderPatch(IdXMLReader):
                     yield psm
                 else:
                     self.skip_invalid_psm += 1
-            peptide_id.setHits(new_hits)
-            self.new_peptide_ids.append(peptide_id)
+            if len(new_hits) > 0:
+                peptide_id.setHits(new_hits)
+                self.new_peptide_ids.append(peptide_id)
 
     def _parse_psm(
             self,

--- a/quantmsrescore/ms2rescore.py
+++ b/quantmsrescore/ms2rescore.py
@@ -72,6 +72,7 @@ class IDXMLReaderPatch(IdXMLReader):
                     yield psm
                 else:
                     self.skip_invalid_psm += 1
+            # If it is a valid Peptide Hits then keep it
             if len(new_hits) > 0:
                 peptide_id.setHits(new_hits)
                 self.new_peptide_ids.append(peptide_id)
@@ -245,6 +246,7 @@ def rescore_idxml(input_file, output_file, config) -> None:
         logging.warning(
             f"Removed {reader.skip_invalid_psm} PSMs without search engine features!"
         )
+        # Synchronised acquisition of new peptide IDs after removing invalid PSMs
         peptide_ids = reader.new_peptide_ids
     else:
         peptide_ids = reader.peptide_ids

--- a/quantmsrescore/ms2rescore.py
+++ b/quantmsrescore/ms2rescore.py
@@ -62,6 +62,10 @@ class IDXMLReaderPatch(IdXMLReader):
 
         psm_list: return [PSM 1]
 
+        The invalid PSM are directly from search engines results (MSGF+). The search engine doesn't report search
+        score features (e.g. MSGF:ScoreRatio) for these invalid PSMs. And we can observe the NumMatchedMainIons of
+        peptide hit is 0. So we should remove these invalid PSMs
+
         """
         for peptide_id in self.peptide_ids:
             new_hits = []

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 # recipe/meta.yaml
 package:
   name: quantms-rescoring
-  version: "0.0.2"
+  version: "0.0.3"
 
 source:
   path: ../


### PR DESCRIPTION
After deleting the invalid PSMs, We should synchronise the deletion of the Peptide Hits if the peptide hits is invalid and return new peptide hits results