### PR TITLE
support ppm tolerance

### DIFF
--- a/quantmsrescore/ms2rescore.py
+++ b/quantmsrescore/ms2rescore.py
@@ -74,9 +74,15 @@ configure_logging()
 )
 @click.option(
     "--ms2_tolerance",
-    help="Fragment mass tolerance [Da](default: `0.05`)",
+    help="Fragment mass tolerance (default: `0.05`)",
     type=float,
     default=0.05,
+)
+@click.option(
+    "--ms2_tolerance_unit",
+    help="Fragment mass tolerance unit (default: Da)",
+    type=str,
+    default="Da",
 )
 @click.option(
     "--calibration_set_size",
@@ -125,6 +131,7 @@ def msrescore2feature(
     force_model,
     find_best_model,
     ms2_tolerance,
+    ms2_tolerance_unit,
     calibration_set_size,
     valid_correlations_size,
     skip_deeplc_retrain,
@@ -189,6 +196,7 @@ def msrescore2feature(
         find_best_model=find_best_model,
         ms2_model_path=ms2_model_dir,
         ms2_tolerance=ms2_tolerance,
+        ms2_tolerance_unit=ms2_tolerance_unit,
         calibration_set_size=calibration_set_size,
         valid_correlations_size=valid_correlations_size,
         skip_deeplc_retrain=skip_deeplc_retrain,


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add support for PPM tolerance unit alongside Da

- Implement conditional tolerance calculation based on unit type

- Add ms2_tolerance_unit parameter throughout codebase

- Enable AlphaPeptDeep as fallback when PPM tolerance with MS2PIP


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CLI Parameter<br/>ms2_tolerance_unit"] --> B["FeatureAnnotator<br/>stores unit"]
  B --> C["AlphaPeptDeepAnnotator<br/>receives unit"]
  C --> D["make_prediction<br/>passes unit"]
  D --> E["_get_targets_for_psm<br/>applies unit logic"]
  E --> F["Conditional Tolerance<br/>PPM or Da"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>alphapeptdeep.py</strong><dd><code>Add PPM tolerance unit support to AlphaPeptDeep</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

quantmsrescore/alphapeptdeep.py

<ul><li>Add <code>ms2_tolerance_unit</code> parameter to <code>AlphaPeptDeepAnnotator.__init__()</code> <br>with default "Da"<br> <li> Pass <code>ms2_tolerance_unit</code> through <code>custom_correlate()</code> and <br><code>make_prediction()</code> functions<br> <li> Implement conditional tolerance calculation in <code>_get_targets_for_psm()</code> <br>to handle both PPM and Da units<br> <li> Uncomment and refactor tolerance logic to multiply by 1e-6 for PPM or <br>use fixed value for Da</ul>


</details>


  </td>
  <td><a href="https://github.com/bigbio/quantms-rescoring/pull/36/files#diff-2a55637c80a4e31d62984d531ec536e52b04154e5349163d0011e0b152b70b90">+14/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>annotator.py</strong><dd><code>Add tolerance unit parameter and PPM fallback logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

quantmsrescore/annotator.py

<ul><li>Add <code>ms2_tolerance_unit</code> parameter to <code>FeatureAnnotator.__init__()</code> with <br>default "Da"<br> <li> Store <code>ms2_tolerance_unit</code> as instance variable <code>_ms2_tolerance_unit</code><br> <li> Add logic to enable AlphaPeptDeep when PPM tolerance is used with <br>MS2PIP (which only supports Da)<br> <li> Pass <code>tolerance_unit</code> parameter to <code>_create_alphapeptdeep_annotator()</code> <br>method</ul>


</details>


  </td>
  <td><a href="https://github.com/bigbio/quantms-rescoring/pull/36/files#diff-c24917fce7900298ecea66bcbedd3bd3152421a130e6db3da19c74c61be09220">+13/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ms2rescore.py</strong><dd><code>Add CLI option for tolerance unit configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

quantmsrescore/ms2rescore.py

<ul><li>Add new CLI option <code>--ms2_tolerance_unit</code> with default value "Da"<br> <li> Update help text for <code>--ms2_tolerance</code> to remove "[Da]" specification<br> <li> Pass <code>ms2_tolerance_unit</code> parameter to <code>FeatureAnnotator</code> initialization<br> <li> Add <code>ms2_tolerance_unit</code> to <code>msrescore2feature()</code> function signature</ul>


</details>


  </td>
  <td><a href="https://github.com/bigbio/quantms-rescoring/pull/36/files#diff-d6a7c234404ec9682d47dca3803cc1755e81134d9f19b11b97264f46cf339296">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

