### PR TITLE
Enabling transfer learning in AlphaPeptDeep

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -19,6 +19,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Remove unnecessary files to release disk space
+      run: |
+        df -h
+        rm -rf /opt/hostedtoolcache
+        df -h
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -20,6 +20,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Remove unnecessary files to release disk space
+      run: |
+        df -h
+        rm -rf /opt/hostedtoolcache
+        df -h
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3
       with:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -22,6 +22,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Remove unnecessary files to release disk space
+      run: |
+        df -h
+        rm -rf /opt/hostedtoolcache
+        df -h
     - name: Set up Python
       uses: actions/setup-python@v3
       with:

--- a/environment.yml
+++ b/environment.yml
@@ -19,4 +19,4 @@ dependencies:
   - pytest
   - ms2pip>=4.0
   - pip:
-    - peptdeep
+    - peptdeep=1.4.0

--- a/environment.yml
+++ b/environment.yml
@@ -19,4 +19,4 @@ dependencies:
   - pytest
   - ms2pip>=4.0
   - pip:
-    - peptdeep=1.4.0
+    - peptdeep==1.4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "quantms-rescoring"
 description = "quantms-rescoring: Python scripts and helpers for the quantMS workflow"
 readme = "README.md"
 license = "MIT"
-version = "0.0.12"
+version = "0.0.13"
 authors = [
     "Yasset Perez-Riverol <ypriverol@gmail.com>",
     "Dai Chengxin <chengxin2024@126.com>",

--- a/quantmsrescore/__init__.py
+++ b/quantmsrescore/__init__.py
@@ -4,4 +4,4 @@ from warnings import filterwarnings
 # Suppress warnings about OPENMS_DATA_PATH
 filterwarnings("ignore", message=".*OPENMS_DATA_PATH.*", category=UserWarning)
 
-__version__ = "0.0.12"
+__version__ = "0.0.13"

--- a/quantmsrescore/alphapeptdeep.py
+++ b/quantmsrescore/alphapeptdeep.py
@@ -1,9 +1,6 @@
-import os.path
-
 import pandas as pd
 from peptdeep.pretrained_models import ModelManager
 from peptdeep.mass_spec.match import match_centroid_mz
-from peptdeep.model.ms2 import pDeepModel
 from alphabase.peptide.fragment import create_fragment_mz_dataframe
 from ms2rescore.feature_generators.base import FeatureGeneratorBase, FeatureGeneratorException
 from typing import Optional, Tuple, List, Union, Generator, Dict, Any

--- a/quantmsrescore/alphapeptdeep.py
+++ b/quantmsrescore/alphapeptdeep.py
@@ -1137,10 +1137,6 @@ def _get_targets_df_for_psm(
         spec_mz_tols = spectrum.mz * ms2_tolerance * 1e-6
     else:
         spec_mz_tols = np.full_like(spectrum.mz, ms2_tolerance)
-    # print(spectrum.mz)
-    # print(ms2_tolerance)  # 0.05
-    # spec_mz_tols = np.full_like(spectrum.mz, ms2_tolerance)
-
     # match
     idx = match_centroid_mz(spectrum.mz, theo_mz, spec_mz_tols).reshape(-1)
     intens = np.where(idx >= 0, spectrum.intensity[idx], 0.0)

--- a/quantmsrescore/alphapeptdeep.py
+++ b/quantmsrescore/alphapeptdeep.py
@@ -791,7 +791,7 @@ def ms2_fine_tune(enumerated_psm_list, psms_df, spec_file, spectrum_id_pattern, 
         # Sort alphapeptdeep results by PSM score and lower score is better
         enumerated_psm_list_copy.sort(key=lambda x: x.score, reverse=higher_score_better)
 
-        # Get a calibration set, the % of psms to be used for calibrarion is defined by calibration_set_size
+        # Get a calibration set, the % of psms to be used for calibration is defined by calibration_set_size
         calibration_set = enumerated_psm_list_copy[
                           : int(len(enumerated_psm_list_copy) * calibration_set_size)
                           ]

--- a/quantmsrescore/alphapeptdeep.py
+++ b/quantmsrescore/alphapeptdeep.py
@@ -761,6 +761,38 @@ def custom_correlate(
 def ms2_fine_tune(enumerated_psm_list, psms_df, spec_file, spectrum_id_pattern, model_mgr,
                   ms2_tolerance, ms2_tolerance_unit, processes, consider_modloss, higher_score_better,
                   calibration_set_size, transfer_learning, transfer_learning_test_ratio, epoch_to_train_ms2):
+    """
+    Fine-tunes the MS2 prediction model using transfer learning on a calibration set of PSMs.
+
+    This function selects a subset of high-confidence PSMs, splits them into calibration and test sets,
+    and performs transfer learning on the MS2 prediction model. It then predicts MS2 spectra for all PSMs
+    using the (optionally) fine-tuned model.
+
+    Args:
+        enumerated_psm_list (List[PSM]): List of PSM objects to use for calibration and prediction.
+        psms_df (pd.DataFrame): DataFrame containing precursor information for all PSMs.
+        spec_file (str or Path): Path to the spectrum file containing observed spectra.
+        spectrum_id_pattern (str): Regex pattern to extract spectrum IDs from the spectrum file.
+        model_mgr (ModelManager): The MS2 prediction model manager instance.
+        ms2_tolerance (float): Tolerance for matching fragment ions (in Da or ppm).
+        ms2_tolerance_unit (str): Unit for ms2_tolerance ("Da" or "ppm").
+        processes (int or None): Number of processes to use for parallel prediction.
+        consider_modloss (bool): Whether to consider modification losses in fragment ion types.
+        higher_score_better (bool): If True, higher PSM scores are better; otherwise, lower scores are better.
+        calibration_set_size (float): Fraction of PSMs to use for calibration (transfer learning).
+        transfer_learning (bool): Whether to perform transfer learning on the MS2 model.
+        transfer_learning_test_ratio (float): Fraction of calibration set to use as test set during transfer learning.
+        epoch_to_train_ms2 (int): Number of epochs to train the MS2 model during transfer learning.
+
+    Returns:
+        Tuple[List[ProcessingResult], Any]: A tuple containing:
+            - List of ProcessingResult objects for each PSM, including predicted and observed spectra and scores.
+            - Model weights or state after (optional) transfer learning.
+
+    Raises:
+        Exception: If any error occurs during transfer learning or prediction.
+
+    """
     if consider_modloss:
         frag_types = ['b_z1', 'y_z1', 'b_z2', 'y_z2',
                       'b_modloss_z1', 'b_modloss_z2',

--- a/quantmsrescore/annotator.py
+++ b/quantmsrescore/annotator.py
@@ -70,7 +70,7 @@ class FeatureAnnotator:
             Force the use of the best MS2 model (default: False).
         consider_modloss: bool, optional
             If modloss ions are considered in the ms2 model. `modloss`
-            ions are mostly useful for phospho MS2 prediciton model.
+            ions are mostly useful for phospho MS2 prediction model.
             Defaults to True.
         transfer_learning_test_ratio: float, optional
             The ratio of test data for MS2 transfer learning.

--- a/quantmsrescore/annotator.py
+++ b/quantmsrescore/annotator.py
@@ -450,7 +450,8 @@ class FeatureAnnotator:
                 f"Using best model: {alphapeptdeep_best_model} with correlation: {alphapeptdeep_best_corr:.4f}")
         else:
             # Fallback to original model if best model doesn't validate
-            if alphapeptdeep_generator.validate_features(psm_list, psms_df, model=original_model):
+            if alphapeptdeep_generator.validate_features(psm_list=psm_list, psms_df=psms_df,
+                                                         model=original_model):
                 logger.warning("Best model validation failed, falling back to original model")
                 model_to_use = original_model
             else:

--- a/quantmsrescore/annotator.py
+++ b/quantmsrescore/annotator.py
@@ -484,6 +484,7 @@ class FeatureAnnotator:
                 logger.info("Running MS2PIP model")
                 ms2pip_best_model, ms2pip_best_corr = ms2pip_generator._find_best_ms2pip_model(calibration_set)
             else:
+                logger.info("MS2PIP model don't support ppm tolerance unit. Only consider AlphaPeptDeep model")
                 original_model = alphapeptdeep_best_model
 
             if alphapeptdeep_best_corr > ms2pip_best_corr:

--- a/quantmsrescore/annotator.py
+++ b/quantmsrescore/annotator.py
@@ -30,7 +30,8 @@ class FeatureAnnotator:
                  ms2_tolerance_unit: str = "Da", calibration_set_size: float = 0.2, valid_correlations_size: float = 0.7,
                  skip_deeplc_retrain: bool = False, processes: int = 2, log_level: str = "INFO",
                  spectrum_id_pattern: str = "(.*)", psm_id_pattern: str = "(.*)", remove_missing_spectra: bool = True,
-                 ms2_only: bool = True, find_best_model: bool = False, consider_modloss: bool = False) -> None:
+                 ms2_only: bool = True, find_best_model: bool = False, consider_modloss: bool = False,
+                 transfer_learning: bool = False) -> None:
         """
         Initialize the Annotator with configuration parameters.
 
@@ -127,6 +128,7 @@ class FeatureAnnotator:
         self._force_model = force_model
         self._find_best_model = find_best_model
         self._consider_modloss = consider_modloss
+        self._transfer_learning = transfer_learning
 
     def build_idxml_data(
             self, idxml_file: Union[str, Path], spectrum_path: Union[str, Path]
@@ -369,7 +371,8 @@ class FeatureAnnotator:
             higher_score_better=self._higher_score_better,
             processes=self._processes,
             force_model=self._force_model,
-            consider_modloss=self._consider_modloss
+            consider_modloss=self._consider_modloss,
+            transfer_learning=self._transfer_learning
         )
 
 

--- a/quantmsrescore/annotator.py
+++ b/quantmsrescore/annotator.py
@@ -72,6 +72,8 @@ class FeatureAnnotator:
             If modloss ions are considered in the ms2 model. `modloss`
             ions are mostly useful for phospho MS2 prediction model.
             Defaults to True.
+        transfer_learning : bool, required
+            Whether to use MS2 transfer learning. Set to True to enable transfer learning for MS2 model.
         transfer_learning_test_ratio: float, optional
             The ratio of test data for MS2 transfer learning.
             Defaults to 0.3.

--- a/quantmsrescore/annotator.py
+++ b/quantmsrescore/annotator.py
@@ -78,8 +78,9 @@ class FeatureAnnotator:
         save_retrain_model: bool, optional
             Save retrained MS2 model.
             Defaults to False.
-        epoch_to_train_ms2: bool, optional
-            Epoch to train AlphaPeptDeep MS2 model.
+        epoch_to_train_ms2: int, optional
+            Epochs to train AlphaPeptDeep MS2 model.
+            Defaults to 20.
         Raises
         ------
         ValueError
@@ -432,6 +433,13 @@ class FeatureAnnotator:
         """
         logger.info("Finding best MS2 model for the dataset")
 
+        # Initialize AlphaPeptDeep annotator
+        try:
+            alphapeptdeep_generator = self._create_alphapeptdeep_annotator(model="generic")
+        except Exception as e:
+            logger.error(f"Failed to initialize AlphaPeptDeep: {e}")
+            raise
+
         # Initialize MS2PIP annotator
         if self._ms2_tolerance_unit == "Da":
             try:
@@ -441,13 +449,9 @@ class FeatureAnnotator:
             except Exception as e:
                 logger.error(f"Failed to initialize MS2PIP: {e}")
                 raise
-
-        # Initialize AlphaPeptDeep annotator
-        try:
-            alphapeptdeep_generator = self._create_alphapeptdeep_annotator(model="generic")
-        except Exception as e:
-            logger.error(f"Failed to initialize AlphaPeptDeep: {e}")
-            raise
+        else:
+            original_model = alphapeptdeep_generator.model
+            model_to_use = original_model
 
         # Get PSM list
         psm_list = self._idxml_reader.psms

--- a/quantmsrescore/annotator.py
+++ b/quantmsrescore/annotator.py
@@ -513,8 +513,10 @@ class FeatureAnnotator:
                     logger.info(f"Using best model: {model_to_use} with correlation: {ms2pip_best_corr:.4f}")
                 else:
                     # Fallback to original model if best model doesn't validate
-                    if ms2pip_generator.validate_features(psm_list, model=original_model):
+                    if ms2pip_generator.validate_features(psm_list,
+                                                          model=original_model if original_model != "generic" else "HCD2021"):
                         logger.warning("Best model validation failed, falling back to original model")
+                        model_to_use = original_model if original_model != "generic" else "HCD2021"
                     else:
                         logger.error("Both best model and original model validation failed")
                         return  # Exit early since no valid model is available

--- a/quantmsrescore/annotator.py
+++ b/quantmsrescore/annotator.py
@@ -94,12 +94,15 @@ class FeatureAnnotator:
         self._deepLC = "deeplc" in feature_annotators
         if "ms2pip" in feature_annotators and ms2_tolerance_unit == "Da":
             self._ms2pip = True
+        else:
+            self._ms2pip = False
         if "alphapeptdeep" in feature_annotators:
             self._alphapeptdeep = True
         elif "ms2pip" in feature_annotators and ms2_tolerance_unit == "ppm":
             self._alphapeptdeep = True
             logger.warning("MS2PIP only supports Da units. AlphaPeptDeep is enabled when setting ppm tolerance!")
-
+        else:
+            self._alphapeptdeep = False
         self.ms2_generator = None
 
         # Parse and validate features

--- a/quantmsrescore/annotator.py
+++ b/quantmsrescore/annotator.py
@@ -422,6 +422,45 @@ class FeatureAnnotator:
             force_model=self._force_model
         )
 
+    def _apply_alphapeptdeep_model(self, alphapeptdeep_generator, alphapeptdeep_best_model,
+                                   alphapeptdeep_best_corr, psm_list, psms_df):
+        """
+        Apply AlphaPeptDeep model to the PSM list.
+
+        Parameters
+        ----------
+        alphapeptdeep_generator : AlphaPeptDeepAnnotator
+            The AlphaPeptDeep annotator instance.
+        alphapeptdeep_best_model : str
+            The best model to use.
+        alphapeptdeep_best_corr : float
+            The correlation of the best model.
+        psm_list : PSMList
+            List of PSMs to annotate.
+        psms_df : pd.DataFrame
+            DataFrame of PSMs.
+        """
+        model_to_use = alphapeptdeep_best_model  # AlphaPeptdeep only has generic model
+        if alphapeptdeep_best_model and alphapeptdeep_generator.validate_features(psm_list=psm_list,
+                                                                                  psms_df=psms_df,
+                                                                                  model=alphapeptdeep_best_model):
+            logger.info(
+                f"Using best model: {alphapeptdeep_best_model} with correlation: {alphapeptdeep_best_corr:.4f}")
+        else:
+            # Fallback to original model if best model doesn't validate
+            if alphapeptdeep_generator.validate_features(psm_list, psms_df, model=alphapeptdeep_best_model):
+                logger.warning("Best model validation failed, falling back to original model")
+            else:
+                logger.error("Both best model and original model validation failed")
+                return False  # Indicate failure
+
+        # Apply the selected model
+        alphapeptdeep_generator.model = model_to_use
+        alphapeptdeep_generator.add_features(psm_list, psms_df)
+        logger.info(f"Successfully applied AlphaPeptDeep annotation using model: {model_to_use}")
+        self.ms2_generator = "AlphaPeptDeep"
+        return True  # Indicate success
+
     def _find_and_apply_ms2_model(self):
         """
         Find and apply the best MS2 model for the dataset.
@@ -489,47 +528,15 @@ class FeatureAnnotator:
 
             # When using ppm tolerance, only AlphaPeptDeep is supported
             if self._ms2_tolerance_unit != "Da":
-                model_to_use = alphapeptdeep_best_model  # AlphaPeptdeep only has generic model
-                if alphapeptdeep_best_model and alphapeptdeep_generator.validate_features(psm_list=psm_list,
-                                                                                          psms_df=psms_df,
-                                                                                          model=alphapeptdeep_best_model):
-                    logger.info(
-                        f"Using best model: {alphapeptdeep_best_model} with correlation: {alphapeptdeep_best_corr:.4f}")
-                else:
-                    # Fallback to original model if best model doesn't validate
-                    if alphapeptdeep_generator.validate_features(psm_list, psms_df, model=alphapeptdeep_best_model):
-                        logger.warning("Best model validation failed, falling back to original model")
-                    else:
-                        logger.error("Both best model and original model validation failed")
-                        return  # Exit early since no valid model is available
-
-                # Apply the selected model
-                alphapeptdeep_generator.model = model_to_use
-                alphapeptdeep_generator.add_features(psm_list, psms_df)
-                logger.info(f"Successfully applied AlphaPeptDeep annotation using model: {model_to_use}")
-                self.ms2_generator = "AlphaPeptDeep"
+                if not self._apply_alphapeptdeep_model(alphapeptdeep_generator, alphapeptdeep_best_model,
+                                                       alphapeptdeep_best_corr, psm_list, psms_df):
+                    return  # Exit early since no valid model is available
 
             # When using Da tolerance, compare AlphaPeptDeep and MS2PIP
             elif alphapeptdeep_best_corr > ms2pip_best_corr:
-                model_to_use = alphapeptdeep_best_model  # AlphaPeptdeep only has generic model
-                if alphapeptdeep_best_model and alphapeptdeep_generator.validate_features(psm_list=psm_list,
-                                                                                          psms_df=psms_df,
-                                                                                          model=alphapeptdeep_best_model):
-                    logger.info(
-                        f"Using best model: {alphapeptdeep_best_model} with correlation: {alphapeptdeep_best_corr:.4f}")
-                else:
-                    # Fallback to original model if best model doesn't validate
-                    if alphapeptdeep_generator.validate_features(psm_list, psms_df, model=alphapeptdeep_best_model):
-                        logger.warning("Best model validation failed, falling back to original model")
-                    else:
-                        logger.error("Both best model and original model validation failed")
-                        return  # Exit early since no valid model is available
-
-                # Apply the selected model
-                alphapeptdeep_generator.model = model_to_use
-                alphapeptdeep_generator.add_features(psm_list, psms_df)
-                logger.info(f"Successfully applied AlphaPeptDeep annotation using model: {model_to_use}")
-                self.ms2_generator = "AlphaPeptDeep"
+                if not self._apply_alphapeptdeep_model(alphapeptdeep_generator, alphapeptdeep_best_model,
+                                                       alphapeptdeep_best_corr, psm_list, psms_df):
+                    return  # Exit early since no valid model is available
 
             else:
                 # Use MS2PIP when Da tolerance and ms2pip has better correlation

--- a/quantmsrescore/annotator.py
+++ b/quantmsrescore/annotator.py
@@ -12,7 +12,6 @@ from quantmsrescore.ms2pip import MS2PIPAnnotator
 from quantmsrescore.openms import OpenMSHelper
 from quantmsrescore.alphapeptdeep import AlphaPeptDeepAnnotator
 
-
 # Get logger for this module
 logger = get_logger(__name__)
 
@@ -27,11 +26,13 @@ class FeatureAnnotator:
 
     def __init__(self, feature_generators: str, only_features: Optional[str] = None, ms2_model: str = "HCD2021",
                  force_model: bool = False, ms2_model_path: str = "models", ms2_tolerance: float = 0.05,
-                 ms2_tolerance_unit: str = "Da", calibration_set_size: float = 0.2, valid_correlations_size: float = 0.7,
+                 ms2_tolerance_unit: str = "Da", calibration_set_size: float = 0.2,
+                 valid_correlations_size: float = 0.7,
                  skip_deeplc_retrain: bool = False, processes: int = 2, log_level: str = "INFO",
                  spectrum_id_pattern: str = "(.*)", psm_id_pattern: str = "(.*)", remove_missing_spectra: bool = True,
                  ms2_only: bool = True, find_best_model: bool = False, consider_modloss: bool = False,
-                 transfer_learning: bool = False) -> None:
+                 transfer_learning: bool = False, transfer_learning_test_ratio: float = 0.3,
+                 save_retrain_model: bool = False, epoch_to_train_ms2: int = 20) -> None:
         """
         Initialize the Annotator with configuration parameters.
 
@@ -71,7 +72,14 @@ class FeatureAnnotator:
             If modloss ions are considered in the ms2 model. `modloss`
             ions are mostly useful for phospho MS2 prediciton model.
             Defaults to True.
-
+        transfer_learning_test_ratio: float, optional
+            The ratio of test data for MS2 transfer learning.
+            Defaults to 0.3.
+        save_retrain_model: bool, optional
+            Save retrained MS2 model.
+            Defaults to False.
+        epoch_to_train_ms2: bool, optional
+            Epoch to train AlphaPeptDeep MS2 model.
         Raises
         ------
         ValueError
@@ -129,6 +137,9 @@ class FeatureAnnotator:
         self._find_best_model = find_best_model
         self._consider_modloss = consider_modloss
         self._transfer_learning = transfer_learning
+        self._transfer_learning_test_ratio = transfer_learning_test_ratio
+        self._save_retrain_model = save_retrain_model
+        self._epoch_to_train_ms2 = epoch_to_train_ms2
 
     def build_idxml_data(
             self, idxml_file: Union[str, Path], spectrum_path: Union[str, Path]
@@ -335,7 +346,8 @@ class FeatureAnnotator:
             # Apply the selected model
             alphapeptdeep_generator.model = model_to_use
             alphapeptdeep_generator.add_features(psm_list, psms_df)
-            logger.info(f"Successfully applied AlphaPeptDeep annotation using model: {model_to_use}")
+            logger.info(
+                f"Successfully applied AlphaPeptDeep annotation using model: {alphapeptdeep_generator._peptdeep_model}")
 
         except Exception as e:
             logger.error(f"Failed to apply AlphaPeptDeep annotation: {e}")
@@ -344,7 +356,7 @@ class FeatureAnnotator:
         return  # Successful completion
 
     def _create_alphapeptdeep_annotator(self, model: Optional[str] = None, tolerance: Optional[float] = None,
-                                        tolerance_unit: Optional[str] = "Da"):
+                                        tolerance_unit: Optional[str] = None):
         """
         Create an AlphaPeptDeep annotator with the specified or default model.
 
@@ -358,6 +370,7 @@ class FeatureAnnotator:
         AlphaPeptDeep
             Configured AlphaPeptDeep annotator.
         """
+
         return AlphaPeptDeepAnnotator(
             ms2_tolerance=tolerance or self._ms2_tolerance,
             ms2_tolerance_unit=tolerance_unit or self._ms2_tolerance_unit,
@@ -372,9 +385,11 @@ class FeatureAnnotator:
             processes=self._processes,
             force_model=self._force_model,
             consider_modloss=self._consider_modloss,
-            transfer_learning=self._transfer_learning
+            transfer_learning=self._transfer_learning,
+            transfer_learning_test_ratio=self._transfer_learning_test_ratio,
+            save_retrain_model=self._save_retrain_model,
+            epoch_to_train_ms2=self._epoch_to_train_ms2
         )
-
 
     def _create_ms2pip_annotator(
             self, model: Optional[str] = None, tolerance: Optional[float] = None
@@ -418,11 +433,14 @@ class FeatureAnnotator:
         logger.info("Finding best MS2 model for the dataset")
 
         # Initialize MS2PIP annotator
-        try:
-            ms2pip_generator = self._create_ms2pip_annotator()
-        except Exception as e:
-            logger.error(f"Failed to initialize MS2PIP: {e}")
-            raise
+        if self._ms2_tolerance_unit == "Da":
+            try:
+                ms2pip_generator = self._create_ms2pip_annotator()
+                original_model = ms2pip_generator.model
+                model_to_use = original_model
+            except Exception as e:
+                logger.error(f"Failed to initialize MS2PIP: {e}")
+                raise
 
         # Initialize AlphaPeptDeep annotator
         try:
@@ -436,9 +454,6 @@ class FeatureAnnotator:
         psms_df = self._idxml_reader.psms_df
 
         try:
-            # Save original model for reference
-            original_model = ms2pip_generator.model
-
             batch_psms_copy = (
                 psm_list.copy()
             )  # Copy ms2pip results to avoid modifying the original list
@@ -452,20 +467,31 @@ class FeatureAnnotator:
             calibration_set = PSMList(psm_list=calibration_set)
             psms_df_without_decoy = psms_df[psms_df["is_decoy"] == 0]
 
-            # Determine which model to use based on configuration and validation
-            model_to_use = original_model
-            logger.info("Running MS2PIP model")
-            ms2pip_best_model, ms2pip_best_corr = ms2pip_generator._find_best_ms2pip_model(calibration_set)
             logger.info("Running AlphaPeptDeep model")
-            alphapeptdeep_best_model, alphapeptdeep_best_corr = alphapeptdeep_generator._find_best_ms2_model(calibration_set, psms_df_without_decoy)
+            alphapeptdeep_best_model, alphapeptdeep_best_corr = alphapeptdeep_generator._find_best_ms2_model(
+                calibration_set, psms_df_without_decoy)
+
+            ms2pip_best_corr = -1  # Initial MS2PIP best correlation
+            ms2pip_best_model = None
+
+            # Determine which model to use based on configuration and validation
+            if self._ms2_tolerance_unit == "Da":
+                # Save original model for reference
+                logger.info("Running MS2PIP model")
+                ms2pip_best_model, ms2pip_best_corr = ms2pip_generator._find_best_ms2pip_model(calibration_set)
+            else:
+                original_model = alphapeptdeep_best_model
+
             if alphapeptdeep_best_corr > ms2pip_best_corr:
-                if alphapeptdeep_best_model and alphapeptdeep_generator.validate_features(psm_list=psm_list, psms_df=psms_df,
+                model_to_use = alphapeptdeep_best_model  # AlphaPeptdeep only has generic model
+                if alphapeptdeep_best_model and alphapeptdeep_generator.validate_features(psm_list=psm_list,
+                                                                                          psms_df=psms_df,
                                                                                           model=alphapeptdeep_best_model):
-                    model_to_use = alphapeptdeep_best_model
-                    logger.info(f"Using best model: {alphapeptdeep_best_model} with correlation: {alphapeptdeep_best_corr:.4f}")
+                    logger.info(
+                        f"Using best model: {alphapeptdeep_best_model} with correlation: {alphapeptdeep_best_corr:.4f}")
                 else:
                     # Fallback to original model if best model doesn't validate
-                    if alphapeptdeep_generator.validate_features(psm_list, psms_df, model=original_model):
+                    if alphapeptdeep_generator.validate_features(psm_list, psms_df, model=alphapeptdeep_best_model):
                         logger.warning("Best model validation failed, falling back to original model")
                     else:
                         logger.error("Both best model and original model validation failed")

--- a/quantmsrescore/ms2_model_manager.py
+++ b/quantmsrescore/ms2_model_manager.py
@@ -125,7 +125,7 @@ class MS2ModelManager(ModelManager):
                         "please reduce the `psm_num_to_train_ms2` "
                         "value according to overall PSM numbers. "
                     )
-                    test_psm_df = []
+                    test_psm_df = pd.DataFrame()
             else:
                 test_psm_df = psm_df.copy()
                 tr_inten_df = pd.DataFrame()

--- a/quantmsrescore/ms2_model_manager.py
+++ b/quantmsrescore/ms2_model_manager.py
@@ -1,0 +1,169 @@
+import pandas as pd
+from peptdeep.pretrained_models import ModelManager, MODEL_ZIP_FILE_PATH, _download_models, psm_sampling_with_important_mods
+from peptdeep.model.ms2 import pDeepModel
+from peptdeep.model.rt import AlphaRTModel
+from peptdeep.model.ccs import AlphaCCSModel
+from peptdeep.model.charge import ChargeModelForAASeq, ChargeModelForModAASeq
+import os
+from peptdeep.utils import logging
+
+
+class MS2ModelManager(ModelManager):
+    def __init__(self,
+                 mask_modloss: bool = False,
+                 device: str = "gpu",
+                 model_dir: str = None,
+                 ):
+        self._train_psm_logging = True
+
+        self.ms2_model: pDeepModel = pDeepModel(
+            mask_modloss=mask_modloss, device=device
+        )
+        self.rt_model: AlphaRTModel = AlphaRTModel(device=device)
+        self.ccs_model: AlphaCCSModel = AlphaCCSModel(device=device)
+
+        self.charge_model: ChargeModelForModAASeq = ChargeModelForModAASeq(
+            device=device
+        )
+
+        if model_dir is not None and os.path.exists(model_dir):
+            self.load_external_models(ms2_model_file=model_dir)
+            self.model_str = model_dir
+        else:
+            _download_models()
+            self.load_installed_models()
+            self.model_str = "generic"
+        self.reset_by_global_settings(reload_models=False)
+
+    def __str__(self):
+        return self.model_str
+
+    def ms2_fine_tuning(self, psms_df: pd.DataFrame,
+                        match_intensity_df: pd.DataFrame,
+                        psm_num_to_train_ms2: int = 100000000,
+                        use_grid_nce_search: bool = False,
+                        top_n_mods_to_train: int = 10,
+                        psm_num_per_mod_to_train_ms2: int = 50,
+                        psm_num_to_test_ms2: int = 0,
+                        train_verbose: bool = False):
+
+        self.psm_num_to_train_ms2 = psm_num_to_train_ms2
+        self.use_grid_nce_search = use_grid_nce_search
+        self.top_n_mods_to_train = top_n_mods_to_train
+        self.psm_num_per_mod_to_train_ms2 = psm_num_per_mod_to_train_ms2
+        self.psm_num_to_test_ms2 = psm_num_to_test_ms2
+        self.train_verbose = train_verbose
+
+        self.train_ms2_model(psms_df, match_intensity_df)
+
+    def train_ms2_model(
+            self,
+            psm_df: pd.DataFrame,
+            matched_intensity_df: pd.DataFrame,
+    ):
+        """
+        Using matched_intensity_df to train/fine-tune the ms2 model.
+
+        1. It will sample `n=self.psm_num_to_train_ms2` PSMs into training dataframe (`tr_df`) to for fine-tuning.
+        2. This method will also consider some important PTMs (`n=self.top_n_mods_to_train`) into `tr_df` for fine-tuning.
+        3. If `self.use_grid_nce_search==True`, this method will call `self.ms2_model.grid_nce_search` to find the best NCE and instrument.
+
+        Parameters
+        ----------
+        psm_df : pd.DataFrame
+            PSM dataframe for fine-tuning
+
+        matched_intensity_df : pd.DataFrame
+            The matched fragment intensities for `psm_df`.
+        """
+        if self.psm_num_to_train_ms2 > 0:
+            if self.psm_num_to_train_ms2 < len(psm_df):
+                tr_df = psm_sampling_with_important_mods(
+                    psm_df,
+                    self.psm_num_to_train_ms2,
+                    self.top_n_mods_to_train,
+                    self.psm_num_per_mod_to_train_ms2,
+                ).copy()
+            else:
+                tr_df = psm_df
+            if len(tr_df) > 0:
+                tr_inten_df = pd.DataFrame()
+                for frag_type in self.ms2_model.charged_frag_types:
+                    if frag_type in matched_intensity_df.columns:
+                        tr_inten_df[frag_type] = matched_intensity_df[frag_type]
+                    else:
+                        tr_inten_df[frag_type] = 0.0
+                # normalize_fragment_intensities(tr_df, tr_inten_df)
+
+                if self.use_grid_nce_search:
+                    self.nce, self.instrument = self.ms2_model.grid_nce_search(
+                        tr_df,
+                        tr_inten_df,
+                        nce_first=model_mgr_settings["transfer"]["grid_nce_first"],
+                        nce_last=model_mgr_settings["transfer"]["grid_nce_last"],
+                        nce_step=model_mgr_settings["transfer"]["grid_nce_step"],
+                        search_instruments=model_mgr_settings["transfer"][
+                            "grid_instrument"
+                        ],
+                    )
+                    tr_df["nce"] = self.nce
+                    tr_df["instrument"] = self.instrument
+                else:
+                    self.set_default_nce_instrument(tr_df)
+        else:
+            tr_df = []
+
+        if self.psm_num_to_test_ms2 > 0:
+            if len(tr_df) > 0:
+                test_psm_df = psm_df[~psm_df.sequence.isin(set(tr_df.sequence))].copy()
+                if len(test_psm_df) > self.psm_num_to_test_ms2:
+                    test_psm_df = test_psm_df.sample(n=self.psm_num_to_test_ms2)
+                elif len(test_psm_df) == 0:
+                    logging.info(
+                        "No enough PSMs for testing MS2 models, "
+                        "please reduce the `psm_num_to_train_ms2` "
+                        "value according to overall PSM numbers. "
+                    )
+                    test_psm_df = []
+            else:
+                test_psm_df = psm_df.copy()
+                tr_inten_df = pd.DataFrame()
+                for frag_type in self.ms2_model.charged_frag_types:
+                    if frag_type in matched_intensity_df.columns:
+                        tr_inten_df[frag_type] = matched_intensity_df[frag_type]
+                    else:
+                        tr_inten_df[frag_type] = 0.0
+            self.set_default_nce_instrument(test_psm_df)
+        else:
+            test_psm_df = []
+
+        if len(test_psm_df) > 0:
+            logging.info(
+                "Testing pretrained MS2 model on testing df:\n"
+                + str(self.ms2_model.test(test_psm_df, tr_inten_df))
+            )
+        if len(tr_df) > 0:
+            if self._train_psm_logging:
+                logging.info(
+                    f"{len(tr_df)} PSMs for MS2 model training/transfer learning"
+                )
+            self.ms2_model.train(
+                tr_df,
+                fragment_intensity_df=tr_inten_df,
+                batch_size=self.batch_size_to_train_ms2,
+                epoch=self.epoch_to_train_ms2,
+                warmup_epoch=self.warmup_epoch_to_train_ms2,
+                lr=self.lr_to_train_ms2,
+                verbose=self.train_verbose,
+            )
+            logging.info(
+                "Testing refined MS2 model on training df:\n"
+                + str(self.ms2_model.test(tr_df, tr_inten_df))
+            )
+        if len(test_psm_df) > 0:
+            logging.info(
+                "Testing refined MS2 model on testing df:\n"
+                + str(self.ms2_model.test(test_psm_df, tr_inten_df))
+            )
+
+        self.model_str = "retrained_model"

--- a/quantmsrescore/ms2_model_manager.py
+++ b/quantmsrescore/ms2_model_manager.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from peptdeep.pretrained_models import ModelManager, _download_models, MODEL_ZIP_FILE_PATH, \
+from peptdeep.pretrained_models import ModelManager, _download_models, model_mgr_settings, MODEL_ZIP_FILE_PATH, \
     psm_sampling_with_important_mods
 from peptdeep.model.ms2 import pDeepModel
 from peptdeep.model.rt import AlphaRTModel
@@ -7,7 +7,6 @@ from peptdeep.model.ccs import AlphaCCSModel
 from peptdeep.model.charge import ChargeModelForModAASeq
 import os
 from peptdeep.utils import logging
-from zipfile import ZipFile
 
 
 class MS2ModelManager(ModelManager):

--- a/quantmsrescore/ms2_model_manager.py
+++ b/quantmsrescore/ms2_model_manager.py
@@ -66,7 +66,7 @@ class MS2ModelManager(ModelManager):
         """
         Using matched_intensity_df to train/fine-tune the ms2 model.
 
-        1. It will sample `n=self.psm_num_to_train_ms2` PSMs into training dataframe (`tr_df`) to for fine-tuning.
+        1. It will sample `n=self.psm_num_to_train_ms2` PSMs into training dataframe (`tr_df`) for fine-tuning.
         2. This method will also consider some important PTMs (`n=self.top_n_mods_to_train`) into `tr_df` for fine-tuning.
         3. If `self.use_grid_nce_search==True`, this method will call `self.ms2_model.grid_nce_search` to find the best NCE and instrument.
 
@@ -95,7 +95,6 @@ class MS2ModelManager(ModelManager):
                         tr_inten_df[frag_type] = matched_intensity_df[frag_type]
                     else:
                         tr_inten_df[frag_type] = 0.0
-                # normalize_fragment_intensities(tr_df, tr_inten_df)
 
                 if self.use_grid_nce_search:
                     self.nce, self.instrument = self.ms2_model.grid_nce_search(
@@ -113,7 +112,7 @@ class MS2ModelManager(ModelManager):
                 else:
                     self.set_default_nce_instrument(tr_df)
         else:
-            tr_df = []
+            tr_df = pd.DataFrame()
 
         if self.psm_num_to_test_ms2 > 0:
             if len(tr_df) > 0:
@@ -137,7 +136,7 @@ class MS2ModelManager(ModelManager):
                         tr_inten_df[frag_type] = 0.0
             self.set_default_nce_instrument(test_psm_df)
         else:
-            test_psm_df = []
+            test_psm_df = pd.DataFrame()
 
         if len(test_psm_df) > 0:
             logging.info(

--- a/quantmsrescore/ms2rescore.py
+++ b/quantmsrescore/ms2rescore.py
@@ -74,9 +74,15 @@ configure_logging()
 )
 @click.option(
     "--ms2_tolerance",
-    help="Fragment mass tolerance [Da](default: `0.05`)",
+    help="Fragment mass tolerance (default: `0.05`)",
     type=float,
     default=0.05,
+)
+@click.option(
+    "--ms2_tolerance_unit",
+    help="Fragment mass tolerance unit (default: Da)",
+    type=str,
+    default="Da",
 )
 @click.option(
     "--calibration_set_size",
@@ -125,6 +131,7 @@ def msrescore2feature(
     force_model,
     find_best_model,
     ms2_tolerance,
+    ms2_tolerance_unit,
     calibration_set_size,
     valid_correlations_size,
     skip_deeplc_retrain,
@@ -189,6 +196,7 @@ def msrescore2feature(
         find_best_model=find_best_model,
         ms2_model_path=ms2_model_dir,
         ms2_tolerance=ms2_tolerance,
+        ms2_tolerance_unit=ms2_tolerance_unit,
         calibration_set_size=calibration_set_size,
         valid_correlations_size=valid_correlations_size,
         skip_deeplc_retrain=skip_deeplc_retrain,

--- a/quantmsrescore/ms2rescore.py
+++ b/quantmsrescore/ms2rescore.py
@@ -116,6 +116,9 @@ configure_logging()
     help="If modloss ions are considered in the ms2 model",
     is_flag=True,
 )
+@click.option("--transfer_learning",
+              help="Enabling transfer learning for AlphaPeptDeep MS2 prediction",
+              is_flag=True)
 @click.pass_context
 def msrescore2feature(
     ctx,
@@ -137,7 +140,8 @@ def msrescore2feature(
     skip_deeplc_retrain,
     spectrum_id_pattern: str,
     psm_id_pattern: str,
-    consider_modloss
+    consider_modloss,
+    transfer_learning
 ):
     """
     Annotate PSMs in an idXML file with additional features using specified models.
@@ -186,6 +190,9 @@ def msrescore2feature(
         If modloss ions are considered in the ms2 model. `modloss`
         ions are mostly useful for phospho MS2 prediciton model.
         Defaults to True.
+    transfer_learning: bool, optional
+        Enabling transfer learning for AlphaPeptDeep MS2 prediction.
+        Defaults to False.
     """
 
     annotator = FeatureAnnotator(
@@ -204,7 +211,8 @@ def msrescore2feature(
         log_level=log_level.upper(),
         spectrum_id_pattern=spectrum_id_pattern,
         psm_id_pattern=psm_id_pattern,
-        consider_modloss=consider_modloss
+        consider_modloss=consider_modloss,
+        transfer_learning=transfer_learning
     )
     annotator.build_idxml_data(idxml, mzml)
     annotator.annotate()

--- a/quantmsrescore/ms2rescore.py
+++ b/quantmsrescore/ms2rescore.py
@@ -189,6 +189,8 @@ def msrescore2feature(
         Whether to find the model with the best performance.
     ms2_tolerance : float
         The tolerance for MS²PIP annotation.
+    ms2_tolerance_unit : str, optional
+        Unit for the fragment mass tolerance, e.g. "Da" or "ppm".
     calibration_set_size : float
         The percentage of PSMs to use for calibration and retraining.
     valid_correlations_size: float

--- a/quantmsrescore/ms2rescore.py
+++ b/quantmsrescore/ms2rescore.py
@@ -138,13 +138,13 @@ def msrescore2feature(
         log_level,
         processes,
         feature_generators,
-        only_features,
-        ms2_model_dir,
-        ms2_model,
-        ms2_tolerance,
-        ms2_tolerance_unit,
         force_model,
         find_best_model,
+        only_features,
+        ms2_model,
+        ms2_model_dir,
+        ms2_tolerance,
+        ms2_tolerance_unit,
         calibration_set_size,
         valid_correlations_size,
         skip_deeplc_retrain,
@@ -201,7 +201,7 @@ def msrescore2feature(
         The regex pattern for PSM IDs.
     consider_modloss: bool, optional
         If modloss ions are considered in the ms2 model. `modloss`
-        ions are mostly useful for phospho MS2 prediciton model.
+        ions are mostly useful for phospho MS2 prediction model.
         Defaults to True.
     transfer_learning: bool, optional
         Enabling transfer learning for AlphaPeptDeep MS2 prediction.
@@ -213,7 +213,7 @@ def msrescore2feature(
         Save retrained MS2 model.
         Defaults to False.
     epoch_to_train_ms2: int, optional
-        Epoch to train AlphaPeptDeep MS2 model.
+        Number of epochs to train AlphaPeptDeep MS2 model. Defaults to 20.
     """
 
     annotator = FeatureAnnotator(

--- a/quantmsrescore/ms2rescore.py
+++ b/quantmsrescore/ms2rescore.py
@@ -126,7 +126,7 @@ configure_logging()
               help="Save retrained AlphaPeptDeep MS2 model weights",
               is_flag=True)
 @click.option("--epoch_to_train_ms2",
-              help="Epoch to train AlphaPeptDeep MS2 model",
+              help="Epochs to train AlphaPeptDeep MS2 model",
               type=int,
               default=20)
 @click.pass_context

--- a/quantmsrescore/ms2rescore.py
+++ b/quantmsrescore/ms2rescore.py
@@ -81,7 +81,7 @@ configure_logging()
 @click.option(
     "--ms2_tolerance_unit",
     help="Fragment mass tolerance unit (default: Da)",
-    type=str,
+    type=click.Choice(['Da', 'ppm'], case_sensitive=False),
     default="Da",
 )
 @click.option(
@@ -119,29 +119,42 @@ configure_logging()
 @click.option("--transfer_learning",
               help="Enabling transfer learning for AlphaPeptDeep MS2 prediction",
               is_flag=True)
+@click.option("--transfer_learning_test_ratio",
+              help="The ratio of test data for MS2 transfer learning",
+              default=0.30)
+@click.option("--save_retrain_model",
+              help="Save retrained AlphaPeptDeep MS2 model weights",
+              is_flag=True)
+@click.option("--epoch_to_train_ms2",
+              help="Epoch to train AlphaPeptDeep MS2 model",
+              type=int,
+              default=20)
 @click.pass_context
 def msrescore2feature(
-    ctx,
-    idxml: str,
-    mzml,
-    output: str,
-    log_level,
-    processes,
-    feature_generators,
-    only_features,
-    ms2_model_dir,
-    ms2_model,
-    force_model,
-    find_best_model,
-    ms2_tolerance,
-    ms2_tolerance_unit,
-    calibration_set_size,
-    valid_correlations_size,
-    skip_deeplc_retrain,
-    spectrum_id_pattern: str,
-    psm_id_pattern: str,
-    consider_modloss,
-    transfer_learning
+        ctx,
+        idxml: str,
+        mzml,
+        output: str,
+        log_level,
+        processes,
+        feature_generators,
+        only_features,
+        ms2_model_dir,
+        ms2_model,
+        ms2_tolerance,
+        ms2_tolerance_unit,
+        force_model,
+        find_best_model,
+        calibration_set_size,
+        valid_correlations_size,
+        skip_deeplc_retrain,
+        spectrum_id_pattern: str,
+        psm_id_pattern: str,
+        consider_modloss,
+        transfer_learning,
+        transfer_learning_test_ratio,
+        save_retrain_model,
+        epoch_to_train_ms2
 ):
     """
     Annotate PSMs in an idXML file with additional features using specified models.
@@ -193,6 +206,14 @@ def msrescore2feature(
     transfer_learning: bool, optional
         Enabling transfer learning for AlphaPeptDeep MS2 prediction.
         Defaults to False.
+    transfer_learning_test_ratio: float, optional
+        The ratio of test data for MS2 transfer learning.
+        Defaults to 0.3.
+    save_retrain_model: bool, optional
+        Save retrained MS2 model.
+        Defaults to False.
+    epoch_to_train_ms2: int, optional
+        Epoch to train AlphaPeptDeep MS2 model.
     """
 
     annotator = FeatureAnnotator(
@@ -212,7 +233,10 @@ def msrescore2feature(
         spectrum_id_pattern=spectrum_id_pattern,
         psm_id_pattern=psm_id_pattern,
         consider_modloss=consider_modloss,
-        transfer_learning=transfer_learning
+        transfer_learning=transfer_learning,
+        transfer_learning_test_ratio=transfer_learning_test_ratio,
+        save_retrain_model=save_retrain_model,
+        epoch_to_train_ms2=epoch_to_train_ms2
     )
     annotator.build_idxml_data(idxml, mzml)
     annotator.annotate()

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ scipy
 pygam
 protobuf
 ms2pip>=4.0
-peptdeep
+peptdeep==1.4.0


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add MS2 transfer learning support for AlphaPeptDeep model

- Implement PPM tolerance unit support alongside Da units

- Create MS2ModelManager class for fine-tuning capabilities

- Add transfer learning configuration parameters to CLI and annotator

- Refactor custom_correlate function to support model manager objects


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User Input<br/>transfer_learning<br/>ms2_tolerance_unit"] --> B["FeatureAnnotator<br/>Configuration"]
  B --> C["AlphaPeptDeepAnnotator"]
  C --> D["MS2ModelManager"]
  D --> E["Fine-tune MS2<br/>Model"]
  E --> F["Predictions with<br/>Retrained Model"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Version bump to 0.0.13</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

quantmsrescore/__init__.py

- Bump version from 0.0.12 to 0.0.13


</details>


  </td>
  <td><a href="https://github.com/bigbio/quantms-rescoring/pull/40/files#diff-0c1cf1e85cbe4600e4f623a49ca689339bc3f3856015a5e17f98ef72a2cb2f20">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Version bump to 0.0.13</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml

- Update version from 0.0.12 to 0.0.13


</details>


  </td>
  <td><a href="https://github.com/bigbio/quantms-rescoring/pull/40/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>alphapeptdeep.py</strong><dd><code>Add transfer learning and PPM tolerance support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

quantmsrescore/alphapeptdeep.py

<ul><li>Add <code>ms2_tolerance_unit</code> parameter to support PPM and Da units<br> <li> Import new <code>MS2ModelManager</code> class for transfer learning<br> <li> Refactor <code>custom_correlate</code> function to accept <code>ModelManager</code> objects <br>instead of model strings<br> <li> Implement transfer learning logic in <code>validate_features</code> and <br><code>add_features</code> methods<br> <li> Add transfer learning parameters: <code>transfer_learning</code>, <br><code>transfer_learning_test_ratio</code>, <code>epoch_to_train_ms2</code><br> <li> Create <code>ms2_fine_tune</code> function replacing <code>make_prediction</code> with <br>fine-tuning capabilities<br> <li> Add <code>_get_targets_df_for_psm</code> function for DataFrame-based target <br>extraction<br> <li> Update tolerance handling to support both PPM and Da units in <br><code>_get_targets_for_psm</code></ul>


</details>


  </td>
  <td><a href="https://github.com/bigbio/quantms-rescoring/pull/40/files#diff-2a55637c80a4e31d62984d531ec536e52b04154e5349163d0011e0b152b70b90">+260/-57</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>annotator.py</strong><dd><code>Add tolerance unit and transfer learning parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

quantmsrescore/annotator.py

<ul><li>Add <code>ms2_tolerance_unit</code> parameter to FeatureAnnotator initialization<br> <li> Implement logic to enable AlphaPeptDeep when PPM tolerance is selected<br> <li> Add transfer learning configuration parameters to annotator<br> <li> Update <code>_create_alphapeptdeep_annotator</code> to pass tolerance unit and <br>transfer learning parameters<br> <li> Modify <code>_find_and_apply_ms2_model</code> to handle PPM tolerance by skipping <br>MS2PIP</ul>


</details>


  </td>
  <td><a href="https://github.com/bigbio/quantms-rescoring/pull/40/files#diff-c24917fce7900298ecea66bcbedd3bd3152421a130e6db3da19c74c61be09220">+68/-27</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ms2_model_manager.py</strong><dd><code>New MS2ModelManager for transfer learning</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

quantmsrescore/ms2_model_manager.py

<ul><li>Create new MS2ModelManager class extending ModelManager<br> <li> Implement <code>ms2_fine_tuning</code> method for transfer learning configuration<br> <li> Implement <code>train_ms2_model</code> method for model fine-tuning with PSM <br>sampling<br> <li> Add <code>save_ms2_model</code> method to persist retrained model weights<br> <li> Support grid NCE search and important PTM sampling during training</ul>


</details>


  </td>
  <td><a href="https://github.com/bigbio/quantms-rescoring/pull/40/files#diff-adeb0f841a5d0910770b4f7c3d6459ac9dc01fe7e312e1b793615f859eb6f4a9">+174/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ms2rescore.py</strong><dd><code>Add CLI options for transfer learning and tolerance units</code></dd></summary>
<hr>

quantmsrescore/ms2rescore.py

<ul><li>Add <code>--ms2_tolerance_unit</code> CLI option supporting Da and ppm choices<br> <li> Add transfer learning CLI options: <code>--transfer_learning</code>, <br><code>--transfer_learning_test_ratio</code>, <code>--save_retrain_model</code>, <br><code>--epoch_to_train_ms2</code><br> <li> Update <code>msrescore2feature</code> function signature to accept new parameters<br> <li> Pass all new parameters to FeatureAnnotator initialization</ul>


</details>


  </td>
  <td><a href="https://github.com/bigbio/quantms-rescoring/pull/40/files#diff-d6a7c234404ec9682d47dca3803cc1755e81134d9f19b11b97264f46cf339296">+62/-22</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unit-aware MS² tolerance (Da/ppm) that affects model selection and enables MS² fine‑tuning with transfer‑learning, configurable test split, epochs, weight reuse and save options.
  * New MS² model manager to coordinate MS² models, support fine‑tuning, evaluation and saving of retrained models.
  * New CLI/annotator options to control tolerance unit, transfer‑learning, test ratio, save‑retrain, and training epochs.

* **Chores**
  * Package version bumped to 0.0.13.
  * Pinned peptdeep dependency to 1.4.0.

* **CI**
  * Added workflow step to free disk space during CI.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->