### PR TITLE
support multiple input to transfer learning

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -23,6 +23,11 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: "3.11"
+    - name: Remove unnecessary files to release disk space
+      run: |
+          df -h
+          rm -rf /opt/hostedtoolcache
+          df -h
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/quantmsrescore/annotator.py
+++ b/quantmsrescore/annotator.py
@@ -505,8 +505,7 @@ class FeatureAnnotator:
         elif is_HCD:
             original_model = alphapeptdeep_generator.model
         else:
-            logger.error(f"Failed to initialize all models")
-            raise
+            logger.error("Failed to initialize all models")
 
         # Get PSM list
         psm_list = self._idxml_reader.psms

--- a/quantmsrescore/idxmlreader.py
+++ b/quantmsrescore/idxmlreader.py
@@ -242,6 +242,8 @@ class IdXMLRescoringReader(IdXMLReader):
             elif self.high_score_better != peptide_id.isHigherScoreBetter():
                 logger.warning("Inconsistent score direction found in idXML file")
 
+            spectrum_ref = peptide_id.getMetaValue("spectrum_reference")
+
             for psm_hit in peptide_id.getHits():
                 if (
                         only_ms2
@@ -269,7 +271,10 @@ class IdXMLRescoringReader(IdXMLReader):
                                              "nce": nce,
                                              "provenance_data": next(iter(psm.provenance_data.keys())),
                                              "instrument": instrument,
+                                             "spectrum_ref": spectrum_ref,
+                                             "filename": self.filename.stem.replace("_comet", "").replace("_msgf", "").replace("_sage", ""),
                                              "is_decoy": OpenMSHelper.is_decoy_peptide_hit(psm_hit),
+                                             "rank": psm_hit.getRank() + 1,
                                              "score": psm_hit.getScore()}, ignore_index=True)
 
         self._psms = PSMList(psm_list=psm_list)

--- a/quantmsrescore/ms2_model_manager.py
+++ b/quantmsrescore/ms2_model_manager.py
@@ -7,6 +7,7 @@ from peptdeep.model.ccs import AlphaCCSModel
 from peptdeep.model.charge import ChargeModelForModAASeq
 import os
 from peptdeep.utils import logging
+import glob
 
 
 class MS2ModelManager(ModelManager):
@@ -27,8 +28,8 @@ class MS2ModelManager(ModelManager):
             device=device
         )
 
-        if model_dir is not None and os.path.exists(os.path.join(model_dir, "ms2.pth")):
-            self.load_external_models(ms2_model_file=os.path.join(model_dir, "ms2.pth"))
+        if model_dir is not None and len(glob.glob(os.path.join(model_dir, "*ms2.pth"))) > 0:
+            self.load_external_models(ms2_model_file=glob.glob(os.path.join(model_dir, "*ms2.pth"))[0])
             self.model_str = model_dir
         else:
             _download_models(MODEL_ZIP_FILE_PATH)
@@ -169,5 +170,5 @@ class MS2ModelManager(ModelManager):
 
         self.model_str = "retrained_model"
 
-    def save_ms2_model(self):
-        self.ms2_model.save("retrained_ms2.pth")
+    def save_ms2_model(self, save_model_dir):
+        self.ms2_model.save(os.path.join(save_model_dir, "retained_ms2.pth"))

--- a/quantmsrescore/rescoring.py
+++ b/quantmsrescore/rescoring.py
@@ -6,7 +6,7 @@ from quantmsrescore.sage_feature import add_sage_feature
 from quantmsrescore.snr import spectrum2feature
 from quantmsrescore.psm_clean import psm_feature_clean
 from quantmsrescore.model_downloader import download_models
-
+from quantmsrescore.transfer_learning import transfer_learning
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
 
@@ -23,6 +23,7 @@ cli.add_command(add_sage_feature)
 cli.add_command(spectrum2feature)
 cli.add_command(psm_feature_clean)
 cli.add_command(download_models)
+cli.add_command(transfer_learning)
 
 
 def main():

--- a/quantmsrescore/transfer_learning.py
+++ b/quantmsrescore/transfer_learning.py
@@ -1,0 +1,375 @@
+import os.path
+
+import click
+import copy
+from pathlib import Path
+from typing import Optional, Set, Union
+from quantmsrescore.logging_config import configure_logging
+import glob
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from quantmsrescore.idxmlreader import IdXMLRescoringReader
+from quantmsrescore.logging_config import get_logger
+from quantmsrescore.openms import OpenMSHelper
+from quantmsrescore.alphapeptdeep import read_spectrum_file, _get_targets_df_for_psm
+from alphabase.peptide.fragment import create_fragment_mz_dataframe
+from peptdeep.mass_spec.match import match_centroid_mz
+import pandas as pd
+import re
+from quantmsrescore.ms2_model_manager import MS2ModelManager
+
+# Get logger for this module
+logger = get_logger(__name__)
+
+
+@click.command(
+    "transfer_learning",
+    short_help="Annotate PSMs in an idXML file using ms2rescore features.",
+)
+@click.option(
+    "-i",
+    "--idxml",
+    help="Path to the idxml containing the PSMs from OpenMS",
+    required=True,
+    type=click.Path(exists=True),
+)
+@click.option(
+    "-s",
+    "--mzml",
+    help="Path to the mzML file containing the spectra use for identification",
+    required=True,
+    type=click.Path(exists=True),
+)
+@click.option(
+    "-o",
+    "--output",
+    help="Path the output idxml for the annotated PSMs",
+)
+@click.option("--log_level", help="Logging level (default: `info`)", default="info")
+@click.option(
+    "--processes",
+    help="Number of parallel processes available to MS²Rescore (default: 4)",
+    type=int,
+    default=4,
+)
+@click.option(
+    "--ms2_model",
+    help="MS²PIP model (default: `HCD2021`)",
+    type=str,
+    default="HCD2021",
+)
+@click.option(
+    "--ms2_model_dir",
+    help="The path of MS²PIP model (default: `./`)",
+    type=str,
+    default="./",
+)
+@click.option(
+    "--ms2_tolerance",
+    help="Fragment mass tolerance (default: `0.05`)",
+    type=float,
+    default=0.05,
+)
+@click.option(
+    "--ms2_tolerance_unit",
+    help="Fragment mass tolerance unit (default: Da)",
+    type=click.Choice(['Da', 'ppm'], case_sensitive=False),
+    default="Da",
+)
+@click.option(
+    "--calibration_set_size",
+    help="Percentage of number of psms to use for calibration and retraining (default: `0.20)",
+    default=0.20,
+)
+@click.option(
+    "--spectrum_id_pattern",
+    help="Pattern for spectrum identification",
+    type=str,
+    default="(.*)",
+)
+@click.option(
+    "--consider_modloss",
+    help="If modloss ions are considered in the ms2 model",
+    is_flag=True,
+)
+@click.option("--transfer_learning_test_ratio",
+              help="The ratio of test data for MS2 transfer learning",
+              default=0.30)
+@click.option("--epoch_to_train_ms2",
+              help="Epochs to train AlphaPeptDeep MS2 model",
+              type=int,
+              default=20)
+@click.option("--save_retrain_model",
+              help="Save retrained AlphaPeptDeep MS2 model weights",
+              is_flag=True)
+@click.pass_context
+def transfer_learning(
+        ctx,
+        idxml: str,
+        mzml,
+        output: str,
+        log_level,
+        processes,
+        ms2_model,
+        ms2_model_dir,
+        ms2_tolerance,
+        ms2_tolerance_unit,
+        calibration_set_size,
+        spectrum_id_pattern: str,
+        consider_modloss,
+        transfer_learning_test_ratio,
+        epoch_to_train_ms2
+):
+    """
+    Annotate PSMs in an idXML file with additional features using specified models.
+
+    This command-line interface (CLI) command processes a PSM file by adding
+    annotations from the MS²PIP and DeepLC models, among others, while preserving
+    existing information. It supports various options for specifying input and
+    output paths, logging levels, and feature generation configurations.
+
+    Parameters
+    ----------
+
+    ctx : click.Context
+        The Click context object.
+    idxml : str
+        Path to the idXML file containing the PSMs.
+    mzml : str
+        Path to the mzML file containing the mass spectrometry deeplc_models.
+    output : str
+        Path to the output idXML file with annotated PSMs.
+    log_level : str
+        The logging level for the CLI command.
+    processes : int
+        The number of parallel processes available for MS²Rescore.
+    feature_generators : str
+        Comma-separated list of feature generators to use for annotation.
+    only_features : str
+        Comma-separated list of features to use for annotation.
+    force_model : bool
+        Whether to force the use of the provided MS²PIP model.
+    find_best_model : bool
+        Whether to find the model with the best performance.
+    ms2_tolerance : float
+        The tolerance for MS²PIP annotation.
+    ms2_tolerance_unit : str, optional
+        Unit for the fragment mass tolerance, e.g. "Da" or "ppm".
+    calibration_set_size : float
+        The percentage of PSMs to use for calibration and retraining.
+    valid_correlations_size: float
+        Fraction of the valid PSM.
+    skip_deeplc_retrain : bool
+        Whether to skip retraining the DeepLC model.
+    spectrum_id_pattern : str
+        The regex pattern for spectrum IDs.
+    psm_id_pattern : str
+        The regex pattern for PSM IDs.
+    consider_modloss: bool, optional
+        If modloss ions are considered in the ms2 model. `modloss`
+        ions are mostly useful for phospho MS2 prediction model.
+        Defaults to True.
+    transfer_learning: bool, optional
+        Enabling transfer learning for AlphaPeptDeep MS2 prediction.
+        Defaults to False.
+    transfer_learning_test_ratio: float, optional
+        The ratio of test data for MS2 transfer learning.
+        Defaults to 0.3.
+    save_retrain_model: bool, optional
+        Save retrained MS2 model.
+        Defaults to False.
+    epoch_to_train_ms2: int, optional
+        Number of epochs to train AlphaPeptDeep MS2 model. Defaults to 20.
+    """
+
+    annotator = AlphaPeptdeepTrainer(
+        ms2_model=ms2_model,
+        ms2_model_path=ms2_model_dir,
+        ms2_tolerance=ms2_tolerance,
+        ms2_tolerance_unit=ms2_tolerance_unit,
+        calibration_set_size=calibration_set_size,
+        processes=processes,
+        log_level=log_level.upper(),
+        spectrum_id_pattern=spectrum_id_pattern,
+        save_retrain_model=save_retrain_model,
+        consider_modloss=consider_modloss,
+        transfer_learning_test_ratio=transfer_learning_test_ratio,
+        epoch_to_train_ms2=epoch_to_train_ms2
+    )
+    annotator.build_idxml_data(idxml, mzml)
+    annotator.fine_tune()
+
+
+class AlphaPeptdeepTrainer:
+    def __init__(self, ms2_model: str = "HCD2021",
+                 ms2_model_path: str = "models", ms2_tolerance: float = 0.05,
+                 ms2_tolerance_unit: str = "Da", calibration_set_size: float = 0.2,
+                 processes: int = 2, log_level: str = "INFO",
+                 save_retrain_model: bool = True,
+                 spectrum_id_pattern: str = "(.*)",
+                 consider_modloss: bool = False,
+                 transfer_learning_test_ratio: float = 0.3,
+                 epoch_to_train_ms2: int = 20):
+        self._idxml_reader = None
+        self._higher_score_better = None
+        self.spec_file = None
+        self.psms_df = []
+        self.processes = processes
+        self.spectrum_id_pattern = spectrum_id_pattern
+        self._consider_modloss = consider_modloss
+        self.calibration_set_size = calibration_set_size
+        self._transfer_learning_test_ratio = transfer_learning_test_ratio
+        self._epoch_to_train_ms2 = epoch_to_train_ms2
+        self._ms2_tolerance = ms2_tolerance
+        self._ms2_tolerance_unit = ms2_tolerance_unit
+        self._model_dir = ms2_model_path
+        self._save_retrain_model = save_retrain_model
+
+    def _read_idxml_file(self, idxml_path, spectrum_path):
+        # Load the idXML file and corresponding mzML file
+        self._idxml_reader = IdXMLRescoringReader(
+            idxml_filename=idxml_path,
+            mzml_file=spectrum_path,
+            only_ms2=True,
+            remove_missing_spectrum=True,
+        )
+        return self._idxml_reader.psms_df
+
+    def build_idxml_data(self, idxml_file, spectrum_path):
+        logger.info(f"Loading data from: {idxml_file}")
+
+        try:
+            # Convert paths to Path objects for consistency
+            idxml_path = Path(idxml_file)
+            spectrum_path = Path(spectrum_path)
+            if idxml_path.is_dir():
+                idxml_files = sorted([f for f in idxml_path.iterdir() if f.suffix.lower() == ".idxml"])
+                mzml_files = sorted([f for f in spectrum_path.iterdir() if f.suffix.lower() == ".mzml"])
+                mzml_map = {f.stem: f for f in mzml_files}
+                pairs = []
+                for idxml_file in idxml_files:
+                    # 去掉不同 idXML 后缀
+                    stem = idxml_file.stem.replace("_comet", "").replace("_sage", "").replace("_msgf", "")
+                    if stem not in mzml_map:
+                        raise click.BadParameter(f"Missing mzML for idXML: {idxml_file.name}")
+                    pairs.append((idxml_file, mzml_map[stem]))
+
+                with ProcessPoolExecutor(max_workers=self.processes) as executor:
+                    future_to_file = {executor.submit(self._read_idxml_file, idxml_file, spectrum_path): idxml_file for
+                                      idxml_file, spectrum_path in pairs}
+                    for future in as_completed(future_to_file):
+                        content = future.result()
+                        self.psms_df.append(content)
+                self.psms_df = pd.concat(self.psms_df, ignore_index=True)
+                decoys = len(self.psms_df[self.psms_df["is_decoy"]])
+                targets = len(self.psms_df) - decoys
+                self.spec_file = mzml_files
+            else:
+                # Load the idXML file and corresponding mzML file
+                self._idxml_reader = IdXMLRescoringReader(
+                    idxml_filename=idxml_path,
+                    mzml_file=spectrum_path,
+                    only_ms2=True,
+                    remove_missing_spectrum=True,
+                )
+                self._higher_score_better = self._idxml_reader.high_score_better
+                self.psms_df = self._idxml_reader.psms_df
+                self.spec_file = [spectrum_path]
+                openms_helper = OpenMSHelper()
+                decoys, targets = openms_helper.count_decoys_targets(self._idxml_reader.oms_peptides)
+
+            logger.info(
+                f"Loaded {len(self.psms_df)} PSMs from {idxml_path.name}: {decoys} decoys and {targets} targets"
+            )
+
+        except Exception as e:
+            logger.error(f"Failed to load input files: {str(e)}")
+            raise
+
+    def fine_tune(self):
+        if self._consider_modloss:
+            frag_types = ['b_z1', 'y_z1', 'b_z2', 'y_z2',
+                          'b_modloss_z1', 'b_modloss_z2',
+                          'y_modloss_z1', 'y_modloss_z2']
+        else:
+            frag_types = ['b_z1', 'y_z1', 'b_z2', 'y_z2']
+
+        calibration_set = self.psms_df[(self.psms_df["is_decoy"] is not True) & (self.psms_df["rank"] == 1)]
+        calibration_set.sort_values(by="score", inplace=True, ascending=not self._higher_score_better)
+        precursor_df = calibration_set[:int(len(self.psms_df) * self.calibration_set_size)]
+        theoretical_mz_df = create_fragment_mz_dataframe(precursor_df, frag_types)
+        precursor_df = precursor_df.set_index("provenance_data")
+
+        # Compile regex for spectrum ID matching
+        try:
+            spectrum_id_regex = re.compile(self.spectrum_id_pattern)
+        except TypeError:
+            spectrum_id_regex = re.compile(r"(.*)")
+
+        # Organize PSMs by spectrum ID
+        # psms_by_specid = _organize_psms_by_spectrum_id(calibration_set)
+
+        match_intensity_df = []
+        current_index = 0
+        # Process each spectrum
+        for sf in self.spec_file:
+            single_df = precursor_df[precursor_df["filename"] == sf.stem]
+            for spectrum in read_spectrum_file(sf.as_posix()):
+
+                # Match spectrum ID with provided regex
+                match = spectrum_id_regex.search(spectrum.identifier)
+                try:
+                    spectrum_id = match[1]
+                except (TypeError, IndexError):
+                    raise exceptions.TitlePatternError(
+                        f"Spectrum title pattern `{spectrum_id_pattern}` could not be matched to "
+                        f"spectrum ID `{spectrum.identifier}`. "
+                        " Are you sure that the regex contains a capturing group?"
+                    )
+
+                # print(spectrum_id)
+                # Skip if no matching PSMs
+                psm = single_df[single_df["spectrum_ref"] == spectrum_id]
+                if psm.shape[0] <= 0:
+                    continue
+
+                # Process each PSM for this spectrum
+                for row_index, row in psm.iterrows():
+                    row = precursor_df.loc[row_index]
+                    mz = theoretical_mz_df.iloc[row["frag_start_idx"]:row["frag_stop_idx"], ]
+                    match_intensity = _get_targets_df_for_psm(
+                        mz, spectrum, self._ms2_tolerance, self._ms2_tolerance_unit
+                    )
+                    fragment_len = match_intensity.shape[0]
+                    precursor_df.loc[row_index, "match_start_idx"] = current_index
+                    precursor_df.loc[row_index, "match_stop_idx"] = current_index + fragment_len
+                    match_intensity_df.append(match_intensity)
+                    current_index += fragment_len
+
+        match_intensity_df = pd.concat(match_intensity_df, ignore_index=True)
+
+        psm_num_to_train_ms2 = int(len(calibration_set) * (1 - self._transfer_learning_test_ratio))
+        psm_num_to_test_ms2 = len(calibration_set) - psm_num_to_train_ms2
+
+        precursor_df.drop(columns=["frag_start_idx", "frag_stop_idx"], inplace=True)
+        precursor_df.rename(columns={
+            "match_start_idx": "frag_start_idx",
+            "match_stop_idx": "frag_stop_idx"
+        }, inplace=True)
+        precursor_df["frag_start_idx"] = precursor_df["frag_start_idx"].astype("int64")
+        precursor_df["frag_stop_idx"] = precursor_df["frag_stop_idx"].astype("int64")
+
+        model_mgr = MS2ModelManager(
+            mask_modloss=not self._consider_modloss,
+            device="cpu",
+            model_dir=self._model_dir
+        )
+
+        model_mgr.ms2_fine_tuning(precursor_df,
+                                  match_intensity_df,
+                                  psm_num_to_train_ms2=psm_num_to_train_ms2,
+                                  psm_num_to_test_ms2=psm_num_to_test_ms2,
+                                  train_verbose=True,
+                                  epoch_to_train_ms2=self._epoch_to_train_ms2)
+
+        if self._save_retrain_model:
+            model_weights.save_ms2_model()


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add transfer learning support for MS2 model fine-tuning with AlphaPeptDeep

- Support multiple input files (directories) for batch processing with parallel execution

- Extend PSM data with spectrum reference, filename, and rank information

- Integrate transfer learning CLI command into main rescoring pipeline


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["idXML + mzML<br/>Single or Multiple"] -->|"build_idxml_data"| B["PSM DataFrame<br/>with metadata"]
  B -->|"fine_tune"| C["Fragment matching<br/>& calibration"]
  C -->|"ms2_fine_tuning"| D["Retrained MS2<br/>Model weights"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>transfer_learning.py</strong><dd><code>New transfer learning module with AlphaPeptDeep trainer</code>&nbsp; &nbsp; </dd></summary>
<hr>

quantmsrescore/transfer_learning.py

<ul><li>New module implementing <code>AlphaPeptdeepTrainer</code> class for MS2 model <br>fine-tuning<br> <li> Supports single and multiple idXML/mzML file pairs with parallel <br>processing<br> <li> Implements spectrum matching, fragment intensity extraction, and model <br>retraining<br> <li> Provides CLI command with configurable parameters for transfer <br>learning workflow</ul>


</details>


  </td>
  <td><a href="https://github.com/bigbio/quantms-rescoring/pull/45/files#diff-1b4761c970df4c4b98b515f3fb0dc69d386b3991796b6272bf7ef45e87ff10a6">+375/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>idxmlreader.py</strong><dd><code>Extend PSM data with spectrum and rank metadata</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

quantmsrescore/idxmlreader.py

<ul><li>Extract spectrum reference metadata from peptide ID for PSM tracking<br> <li> Add filename (cleaned of search engine suffixes) to PSM dataframe<br> <li> Add PSM rank information to dataframe for ranking purposes<br> <li> Enhance PSM data structure with additional metadata fields</ul>


</details>


  </td>
  <td><a href="https://github.com/bigbio/quantms-rescoring/pull/45/files#diff-d26cc906cf8309c5a58ce46c1520c9287431244aa111b617fe60af405f37ad98">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rescoring.py</strong><dd><code>Register transfer learning command in CLI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

quantmsrescore/rescoring.py

<ul><li>Import new <code>transfer_learning</code> module from quantmsrescore package<br> <li> Register <code>transfer_learning</code> command with CLI command group<br> <li> Enable transfer learning functionality in main CLI interface</ul>


</details>


  </td>
  <td><a href="https://github.com/bigbio/quantms-rescoring/pull/45/files#diff-2e0096b503447e66e2e2eccbfc4185d8739965b6d21345c528b92b7ba47bc167">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>python-app.yml</strong><dd><code>Add disk space cleanup in CI workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/python-app.yml

<ul><li>Add duplicate disk space cleanup step before dependency installation<br> <li> Improves CI/CD reliability by freeing up hosted toolcache space<br> <li> Ensures sufficient disk space for test environment setup</ul>


</details>


  </td>
  <td><a href="https://github.com/bigbio/quantms-rescoring/pull/45/files#diff-d7b3e1cc0b909c52439e5d8d3f602f70644d0f6b62a54825968d819f7a5bee89">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

