### PR TITLE
Update permissions for /work directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,6 @@ ENV PEPTDEEP_HOME=/work
 ENV MPLCONFIGDIR=/work/.config/matplotlib
 
 WORKDIR /work
-RUN chmod -R 777 /work
+RUN chmod -R 755 /work
 
 RUN python3.11 -c "import pyopenms; print('pyOpenMS imported successfully')"


### PR DESCRIPTION
Changed permissions of /work directory from 777 to 755.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted permissions in the Docker container image.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->