### PR TITLE
forced peptdeep version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ scipy = "*"
 pygam = "*"
 protobuf= "*"
 ms2pip = ">=4.0"
-peptdeep = "*"
+peptdeep = "1.4.0"
 psutil = "*"  # For memory-aware process count in HPC environments
 
 [tool.poetry.urls]


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Pin peptdeep dependency to version 1.4.0

- Replace wildcard version constraint with specific release


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["peptdeep wildcard"] -- "pin to specific version" --> B["peptdeep 1.4.0"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Pin peptdeep to specific version 1.4.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml

<ul><li>Changed peptdeep dependency from wildcard version <code>"*"</code> to pinned <br>version <code>"1.4.0"</code><br> <li> Ensures reproducible builds with a specific known-working version</ul>


</details>


  </td>
  <td><a href="https://github.com/bigbio/quantms-rescoring/pull/61/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

