### PR TITLE
fix(ci): workflow_dispatch could never push images (string vs boolean comparison)

### DIFF
--- a/.github/workflows/quantms-rescoring-containers.yml
+++ b/.github/workflows/quantms-rescoring-containers.yml
@@ -76,7 +76,7 @@
        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25
        with:
          context: .
-         push: ${{ (github.event.inputs.push_images == true || github.event.inputs.push_images == '') }}
+         push: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.push_images == 'true' }}
          tags: |
            ghcr.io/bigbio/quantms-rescoring:latest
            ghcr.io/bigbio/quantms-rescoring:${{ steps.version.outputs.VERSION }}
@@ -96,7 +96,7 @@
          sudo rm -rf /var/lib/apt/lists/*
 
      - name: Set up Singularity
-       if: ${{ (github.event.inputs.push_images == true || github.event.inputs.push_images == '') }}
+       if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.push_images == 'true' }}
        uses: eWaterCycle/setup-singularity@931d4e31109e875b13309ae1d07c70ca8fbc8537
        with:
          singularity-version: 3.8.7
@@ -105,7 +105,7 @@
        run: mkdir -p /tmp/singularity-tmp /tmp/singularity-cache /tmp/singularity-lib
 
      - name: Convert Docker image to Singularity
-       if: ${{ (github.event.inputs.push_images == true || github.event.inputs.push_images == '') }}
+       if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.push_images == 'true' }}
        run: |
          singularity build --disable-cache quantms-rescoring.sif docker://ghcr.io/bigbio/quantms-rescoring:latest
          ls -la quantms-rescoring.sif


### PR DESCRIPTION
`github.event.inputs.*` is always a **string**, so `github.event.inputs.push_images == true` compares `"true"` against a boolean and is **always false**.

Consequences on `workflow_dispatch` (even with *Push images = true*):
- **Set up Singularity** was skipped (condition false), but **Login and Deploy Container** (`if: github.event_name != 'pull_request'`) still ran → `singularity: command not found`, **exit 127** — observed in run [30201133224](https://github.com/bigbio/quantms-rescoring/actions/runs/30201133224).
- The docker `push:` used the same broken expression, so images were **not pushed** either.

Only `push`/`release` events worked, because their empty input matched the `== ''` branch.

**Fix:** `github.event_name != 'workflow_dispatch' || github.event.inputs.push_images == 'true'` — non-dispatch events always push (unchanged behavior); dispatch pushes when the input string is `'true'`.

Makes manual container builds actually work, which is needed to publish a container from a branch without merging to main first.