### PR TITLE
feat(consensus): generalize feature union to any registered engine set (SAGE)

### DIFF
--- a/quantmsrescore/consensus_features.py
+++ b/quantmsrescore/consensus_features.py
@@ -1,47 +1,48 @@
-"""
-Two-engine (comet + msgf) Percolator feature construction for the merged
-(consensus) idparquet.
+"""Multi-engine (consensus) Percolator feature construction for the merged
+idparquet.
 
 This module is intentionally dependency-free (no pyopenms / ms2rescore / deeplc
-imports) so the two-engine merge logic can be unit-tested in isolation, the same
-way the original engine-source indicators were.
+imports) so the merge logic can be unit-tested in isolation, the same way the
+original engine-source indicators were.
 
 The defect this fixes
 ---------------------
-When quantms searches with two engines (``comet,msgf``) their PSMs are merged
-into a single idparquet and rescored by *one* joint PercolatorAdapter. The
-previous merged representation was defective in two ways:
+When quantms searches with more than one engine (``comet,msgf``, ``comet,sage``,
+``msgf,sage``, ``comet,msgf,sage``) their PSMs are merged into a single
+idparquet and rescored by *one* joint PercolatorAdapter. The previous merged
+representation was defective in two ways:
 
 1. **Feature collapse.** ``extra_features`` (the list PercolatorAdapter uses)
-   was reduced to only the four primary raw scores
+   was reduced to only the handful of primary raw scores
    (``MS:1002049`` msgf RawScore, ``MS:1002052`` msgf SpecEValue,
-   ``MS:1002252`` comet xcorr, ``MS:1002257`` comet expect). The ~30 rich
-   per-engine features that OpenMS already stores in ``psm_metavalues``
-   (comet deltaCn/spscore/lnExpect..., MS-GF+ ExplainedIonCurrentRatio,
+   ``MS:1002252`` comet xcorr, ``MS:1002257`` comet expect,
+   ``ln(hyperscore)`` sage). The ~30 rich per-engine features that OpenMS
+   already stores in ``psm_metavalues`` (comet deltaCn/spscore/lnExpect...,
+   MS-GF+ ExplainedIonCurrentRatio, Sage longest_b/longest_y/matched_peaks,
    error statistics, ...) were dropped.
 
 2. **Global worst-case imputation of the primaries.** For a single-engine PSM
-   the *other* engine's two primary scores were filled with one global
-   worst-case constant, so the feature space was half constant and Percolator
-   could not tell "engine did not identify this PSM" from "engine scored it
-   badly".
+   the *other* engine's primary scores were filled with one global worst-case
+   constant, so the feature space was largely constant and Percolator could not
+   tell "engine did not identify this PSM" from "engine scored it badly".
 
 ~80% of PSMs in a two-engine run are single-engine, and single-engine PSMs are
-~45% decoy (vs ~8% decoy for PSMs found by *both* engines). With a half-constant
-4-feature space Percolator cannot separate that single-engine decoy flood, so at
-the protein level the target:decoy ratio never clears 1% and picked protein FDR
-(EPIFANY) returns zero proteins ("No proteins left after FDR filtering", exit 8).
+~45% decoy (vs ~8% decoy for PSMs found by *both* engines). With a
+half-constant 4-feature space Percolator cannot separate that single-engine
+decoy flood, so at the protein level the target:decoy ratio never clears 1% and
+picked protein FDR (EPIFANY) returns zero proteins ("No proteins left after FDR
+filtering", exit 8).
 
 The fix (evidence-based; see the experiment writeup)
 ----------------------------------------------------
-Feed the *union* of both engines' rich, numeric features to the single joint
-Percolator, with:
+Feed the *union* of every configured engine's rich, numeric features to the
+single joint Percolator, with:
 
 * **orientation-aware, per-feature worst-case imputation** for the missing
   engine (each feature imputed to its own worst value, not one global constant);
 * **always-defined engine-source indicators** (``CONSENSUS:comet`` /
-  ``CONSENSUS:msgf``, 0/1 on every PSM) so Percolator has an explicit,
-  never-missing signal for which engine(s) identified the PSM.
+  ``CONSENSUS:msgf`` / ``CONSENSUS:sage``, 0/1 on every PSM) so Percolator has
+  an explicit, never-missing signal for which engine(s) identified the PSM.
 
 On MSV000085836_v2 this feature union recovered more target proteins at 1%
 protein FDR (classic *and* picked) than the comet-only reference and clearly
@@ -49,26 +50,67 @@ more than the collapsed 4-feature baseline, while the collapsed baseline scored
 *below* comet-only. String/categorical metavalues (``protein_references``,
 ``AssumedDissociationMethod``) are intentionally excluded so PercolatorAdapter
 receives a purely numeric feature table.
+
+Engines are described by :data:`ENGINE_REGISTRY`. Adding an engine means adding
+one :class:`EngineSpec`; nothing else in the pipeline needs to change.
+
+Feature orientation
+-------------------
+``orientation`` maps a feature name to ``True`` (higher is better), ``False``
+(lower is better) or ``None`` (**no confidence ordering**). The first two are
+imputed to the worst value observed for that feature. ``None`` features are
+imputed to the *midpoint* of their observed range — a deliberately
+non-informative fill, because imputing an extreme for a feature that does not
+encode confidence would inject a false signal in whichever direction we
+guessed. This is used for Sage's ``scored_candidates`` (a property of the
+spectrum's search space, not of PSM quality), where an extreme fill in either
+direction would be an unjustified claim.
 """
 
 from __future__ import annotations
 
-from typing import Dict, List, Optional, Set, Tuple
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Sequence, Set, Tuple
 
-# Percolator feature names for the engine-source indicators.
-CONSENSUS_COMET_FEATURE = "CONSENSUS:comet"
-CONSENSUS_MSGF_FEATURE = "CONSENSUS:msgf"
+# Suffixes used to stash the running range of an unordered (``None``)
+# orientation feature inside the same accumulator dict, so the accumulator stays
+# a plain ``dict`` and callers need no special type.
+_MIN_SUFFIX = "::__min__"
+_MAX_SUFFIX = "::__max__"
 
-# Metavalues that are ONLY present when the respective engine genuinely
-# identified the PSM. They are never produced by imputation, so they are safe
-# presence markers even after imputation has run.
-COMET_PRESENCE_MARKERS: Tuple[str, ...] = ("COMET:xcorr", "COMET:deltaCn", "COMET:spscore")
-MSGF_PRESENCE_MARKERS: Tuple[str, ...] = ("MS:1002050", "ExplainedIonCurrentRatio")
 
-# Curated, non-redundant numeric feature -> higher_is_better orientation.
-# Only numeric metavalues are listed; anything not here is left untouched.
-# (These are the exact feature sets validated in the two-engine experiment.)
-COMET_FEATURE_ORIENTATION: Dict[str, bool] = {
+@dataclass(frozen=True)
+class EngineSpec:
+    """Everything the consensus builder needs to know about one search engine.
+
+    Parameters
+    ----------
+    label
+        The engine name as it appears in ``idparquet_reader.merge_search_engines``
+        (e.g. ``"MS-GF+"``).
+    key
+        Short lowercase token used to build the indicator feature name
+        (``CONSENSUS:<key>``).
+    presence_markers
+        Metavalues that indicate this engine genuinely identified the PSM.
+        Presence detection always runs on the *raw* metavalues before
+        imputation, so any of the engine's own features are valid markers.
+    orientation
+        Curated numeric feature -> ``True`` (higher better) / ``False`` (lower
+        better) / ``None`` (unordered, midpoint-imputed).
+    """
+
+    label: str
+    key: str
+    presence_markers: Tuple[str, ...]
+    orientation: Dict[str, Optional[bool]]
+
+    @property
+    def indicator(self) -> str:
+        return f"CONSENSUS:{self.key}"
+
+
+COMET_FEATURE_ORIENTATION: Dict[str, Optional[bool]] = {
     "COMET:xcorr": True,          # MS:1002252 (primary)
     "COMET:deltaCn": True,        # MS:1002253
     "COMET:deltaLCn": True,
@@ -84,7 +126,7 @@ COMET_FEATURE_ORIENTATION: Dict[str, bool] = {
     "MS:1002258": True,           # matched ions
     "MS:1002259": True,           # total ions
 }
-MSGF_FEATURE_ORIENTATION: Dict[str, bool] = {
+MSGF_FEATURE_ORIENTATION: Dict[str, Optional[bool]] = {
     "MS:1002049": True,           # RawScore (primary)
     "MS:1002050": True,           # DeNovoScore
     "MS:1002052": False,          # SpecEValue (primary)
@@ -100,10 +142,100 @@ MSGF_FEATURE_ORIENTATION: Dict[str, bool] = {
     "MeanErrorAll": False,
     "StdevErrorAll": False,
 }
-UNION_FEATURE_ORIENTATION: Dict[str, bool] = {
+# Sage feature names as emitted into psm_metavalues by quantms (the ``psm_file``
+# rows of Sage's feature table; see ``sage_feature.py``). ``ln(hyperscore)`` is
+# the primary score and is written without the ``SAGE:`` prefix by the merger.
+SAGE_FEATURE_ORIENTATION: Dict[str, Optional[bool]] = {
+    "ln(hyperscore)": True,               # primary
+    "SAGE:ln(delta_next)": True,          # bigger gap to the runner-up = better
+    "SAGE:ln(matched_intensity_pct)": True,
+    "SAGE:matched_peaks": True,
+    "SAGE:longest_b": True,
+    "SAGE:longest_y": True,
+    "SAGE:longest_y_pct": True,
+    # Number of candidates scored for the spectrum. This describes the search
+    # space, not the quality of the match, so it has no confidence ordering:
+    # imputing either extreme would assert something we have not measured.
+    # Midpoint-imputed instead (see module docstring).
+    "SAGE:scored_candidates": None,
+}
+
+ENGINE_REGISTRY: Dict[str, EngineSpec] = {
+    "Comet": EngineSpec(
+        label="Comet",
+        key="comet",
+        presence_markers=("COMET:xcorr", "COMET:deltaCn", "COMET:spscore"),
+        orientation=COMET_FEATURE_ORIENTATION,
+    ),
+    "MS-GF+": EngineSpec(
+        label="MS-GF+",
+        key="msgf",
+        presence_markers=("MS:1002050", "ExplainedIonCurrentRatio"),
+        orientation=MSGF_FEATURE_ORIENTATION,
+    ),
+    "Sage": EngineSpec(
+        label="Sage",
+        key="sage",
+        presence_markers=(
+            "SAGE:matched_peaks",
+            "SAGE:longest_b",
+            "SAGE:longest_y",
+            "SAGE:ln(delta_next)",
+        ),
+        orientation=SAGE_FEATURE_ORIENTATION,
+    ),
+}
+
+DEFAULT_ENGINES: Tuple[str, ...] = ("Comet", "MS-GF+")
+
+# Backwards-compatible aliases (the two-engine API predates the registry).
+CONSENSUS_COMET_FEATURE = ENGINE_REGISTRY["Comet"].indicator
+CONSENSUS_MSGF_FEATURE = ENGINE_REGISTRY["MS-GF+"].indicator
+CONSENSUS_SAGE_FEATURE = ENGINE_REGISTRY["Sage"].indicator
+COMET_PRESENCE_MARKERS: Tuple[str, ...] = ENGINE_REGISTRY["Comet"].presence_markers
+MSGF_PRESENCE_MARKERS: Tuple[str, ...] = ENGINE_REGISTRY["MS-GF+"].presence_markers
+SAGE_PRESENCE_MARKERS: Tuple[str, ...] = ENGINE_REGISTRY["Sage"].presence_markers
+
+UNION_FEATURE_ORIENTATION: Dict[str, Optional[bool]] = {
     **COMET_FEATURE_ORIENTATION,
     **MSGF_FEATURE_ORIENTATION,
 }
+
+
+def supported_engines() -> Set[str]:
+    """Engine labels this module can build consensus features for."""
+    return set(ENGINE_REGISTRY)
+
+
+def is_supported_engine_set(engine_labels: Iterable[str]) -> bool:
+    """True when every configured engine has an :class:`EngineSpec`.
+
+    A merge containing an unknown engine must NOT take the consensus path: we
+    would impute only the known engines' features and silently leave the unknown
+    engine's features missing on the other engines' PSMs.
+    """
+    labels = list(engine_labels or [])
+    return bool(labels) and set(labels) <= supported_engines()
+
+
+def _specs(engine_labels: Optional[Sequence[str]] = None) -> List[EngineSpec]:
+    labels = list(engine_labels) if engine_labels else list(DEFAULT_ENGINES)
+    return [ENGINE_REGISTRY[label] for label in labels if label in ENGINE_REGISTRY]
+
+
+def union_feature_orientation(
+    engine_labels: Optional[Sequence[str]] = None,
+) -> Dict[str, Optional[bool]]:
+    """Merged feature -> orientation map for the configured engines."""
+    merged: Dict[str, Optional[bool]] = {}
+    for spec in _specs(engine_labels):
+        merged.update(spec.orientation)
+    return merged
+
+
+def indicator_names(engine_labels: Optional[Sequence[str]] = None) -> Set[str]:
+    """``CONSENSUS:<engine>`` indicator names for the configured engines."""
+    return {spec.indicator for spec in _specs(engine_labels)}
 
 
 def is_merged_engine(engine_label) -> bool:
@@ -140,32 +272,50 @@ def _meta_value(psm_metavalues, name: str):
     return None
 
 
-def detect_engine_sources(psm_metavalues) -> Tuple[bool, bool]:
-    """Detect which engine(s) genuinely identified a PSM.
+def detect_engines(
+    psm_metavalues,
+    engine_labels: Optional[Sequence[str]] = None,
+) -> Dict[str, bool]:
+    """Detect which of the configured engines genuinely identified a PSM.
 
-    Relies on auxiliary, never-imputed markers, so it stays correct even after
-    imputation has added the missing engine's features.
+    Must be called on the RAW metavalues, before :func:`impute_union_features`
+    adds the missing engines' features.
 
     Returns
     -------
-    (comet_present, msgf_present) : tuple[bool, bool]
+    dict
+        engine label -> ``True``/``False``.
     """
-    comet = any(_has_meta(psm_metavalues, m) for m in COMET_PRESENCE_MARKERS)
-    msgf = any(_has_meta(psm_metavalues, m) for m in MSGF_PRESENCE_MARKERS)
-    return comet, msgf
+    return {
+        spec.label: any(_has_meta(psm_metavalues, m) for m in spec.presence_markers)
+        for spec in _specs(engine_labels)
+    }
+
+
+def detect_engine_sources(psm_metavalues) -> Tuple[bool, bool]:
+    """Two-engine compatibility wrapper returning ``(comet, msgf)``.
+
+    Prefer :func:`detect_engines`, which supports any registered engine set.
+    """
+    found = detect_engines(psm_metavalues, engine_labels=("Comet", "MS-GF+"))
+    return found["Comet"], found["MS-GF+"]
 
 
 def update_worst_case(
     psm_metavalues,
     worst: Dict[str, float],
-    orientation: Optional[Dict[str, bool]] = None,
+    orientation: Optional[Dict[str, Optional[bool]]] = None,
 ) -> Dict[str, float]:
-    """Accumulate per-feature orientation-aware worst-case values in-place.
+    """Accumulate per-feature imputation constants in-place.
 
-    ``worst`` maps feature name -> the worst (least confident) value seen so far:
-    the minimum for higher-is-better features, the maximum otherwise. Only
-    values genuinely present on a PSM contribute; imputed constants never do
-    because this must be run in a first pass over the *raw* merged metavalues.
+    For ordered features ``worst`` maps feature name -> the worst (least
+    confident) value seen so far: the minimum for higher-is-better features, the
+    maximum otherwise. For unordered (``None``) features it maps to the midpoint
+    of the observed range, tracked via two private companion keys.
+
+    Only values genuinely present on a PSM contribute; imputed constants never
+    do, because this must be run in a first pass over the *raw* merged
+    metavalues.
     """
     if orientation is None:
         orientation = UNION_FEATURE_ORIENTATION
@@ -177,7 +327,13 @@ def update_worst_case(
             value = float(raw)
         except (TypeError, ValueError):
             continue
-        if name not in worst:
+        if higher_better is None:
+            lo_key, hi_key = name + _MIN_SUFFIX, name + _MAX_SUFFIX
+            lo = min(worst.get(lo_key, value), value)
+            hi = max(worst.get(hi_key, value), value)
+            worst[lo_key], worst[hi_key] = lo, hi
+            worst[name] = (lo + hi) / 2.0
+        elif name not in worst:
             worst[name] = value
         else:
             worst[name] = min(worst[name], value) if higher_better else max(worst[name], value)
@@ -187,13 +343,13 @@ def update_worst_case(
 def impute_union_features(
     psm_metavalues,
     worst: Dict[str, float],
-    orientation: Optional[Dict[str, bool]] = None,
+    orientation: Optional[Dict[str, Optional[bool]]] = None,
 ) -> List:
     """Ensure every union feature is defined on ``psm_metavalues``.
 
-    Any union feature missing from this PSM (i.e. belonging to the engine that
-    did not identify it) is filled with that feature's own worst-case constant
-    from ``worst``. Idempotent: features already present are left untouched.
+    Any union feature missing from this PSM (i.e. belonging to an engine that
+    did not identify it) is filled with that feature's own constant from
+    ``worst``. Idempotent: features already present are left untouched.
     """
     if orientation is None:
         orientation = UNION_FEATURE_ORIENTATION
@@ -213,34 +369,47 @@ def add_engine_source_features(
     psm_metavalues,
     comet_present: Optional[bool] = None,
     msgf_present: Optional[bool] = None,
+    presence: Optional[Dict[str, bool]] = None,
+    engine_labels: Optional[Sequence[str]] = None,
 ) -> Tuple[List, Set[str]]:
-    """Append the two engine-source indicator features to ``psm_metavalues``.
+    """Append the engine-source indicator features to ``psm_metavalues``.
 
-    The indicators are always defined (0 or 1) for every PSM, so Percolator never
-    sees a missing value for them. Idempotent.
+    The indicators are always defined (0 or 1) for every PSM, so Percolator
+    never sees a missing value for them. Idempotent.
 
-    Returns
-    -------
-    (psm_metavalues, feature_names) : tuple[list, set[str]]
+    ``presence`` (engine label -> bool) is the N-engine form. The
+    ``comet_present`` / ``msgf_present`` keyword arguments are the original
+    two-engine API and still work; when both forms are given, ``presence`` wins
+    for the engines it names.
     """
-    if comet_present is None or msgf_present is None:
-        detected_comet, detected_msgf = detect_engine_sources(psm_metavalues)
-        if comet_present is None:
-            comet_present = detected_comet
-        if msgf_present is None:
-            msgf_present = detected_msgf
+    specs = _specs(engine_labels if presence is None else list(presence))
+    resolved: Dict[str, bool] = {}
+    if presence:
+        resolved.update({k: bool(v) for k, v in presence.items()})
+    legacy = {"Comet": comet_present, "MS-GF+": msgf_present}
+    for label, value in legacy.items():
+        if value is not None and label not in resolved:
+            resolved[label] = bool(value)
+
+    missing = [s.label for s in specs if s.label not in resolved]
+    if missing:
+        detected = detect_engines(psm_metavalues, engine_labels=missing)
+        resolved.update(detected)
 
     psm_metavalues = _to_list(psm_metavalues)
     existing = {item.get("name") for item in psm_metavalues if isinstance(item, dict)}
-    for name, present in (
-        (CONSENSUS_COMET_FEATURE, comet_present),
-        (CONSENSUS_MSGF_FEATURE, msgf_present),
-    ):
-        if name not in existing:
+    names: Set[str] = set()
+    for spec in specs:
+        names.add(spec.indicator)
+        if spec.indicator not in existing:
             psm_metavalues.append(
-                {"name": name, "value": "1" if present else "0", "value_type": "int"}
+                {
+                    "name": spec.indicator,
+                    "value": "1" if resolved.get(spec.label) else "0",
+                    "value_type": "int",
+                }
             )
-    return psm_metavalues, {CONSENSUS_COMET_FEATURE, CONSENSUS_MSGF_FEATURE}
+    return psm_metavalues, names
 
 
 def build_consensus_features(
@@ -248,27 +417,41 @@ def build_consensus_features(
     worst: Dict[str, float],
     comet_present: Optional[bool] = None,
     msgf_present: Optional[bool] = None,
-    orientation: Optional[Dict[str, bool]] = None,
+    orientation: Optional[Dict[str, Optional[bool]]] = None,
+    presence: Optional[Dict[str, bool]] = None,
+    engine_labels: Optional[Sequence[str]] = None,
 ) -> List:
-    """Full per-PSM transform: detect engine origin, impute the missing engine's
-    union features at their worst-case, and add the always-defined indicators.
+    """Full per-PSM transform: detect engine origin, impute the missing engines'
+    union features at their imputation constants, and add the always-defined
+    indicators.
 
     Detection is done on the raw metavalues BEFORE imputation (imputation adds
-    the missing engine's features, so it must not be used as a presence signal).
+    the missing engines' features, so it must not be used as a presence signal).
     """
-    if comet_present is None or msgf_present is None:
-        dc, dm = detect_engine_sources(psm_metavalues)
-        comet_present = dc if comet_present is None else comet_present
-        msgf_present = dm if msgf_present is None else msgf_present
+    labels = list(presence) if presence else (list(engine_labels) if engine_labels else None)
+    if presence is None:
+        detected = detect_engines(psm_metavalues, engine_labels=labels)
+        presence = dict(detected)
+        if comet_present is not None:
+            presence["Comet"] = bool(comet_present)
+        if msgf_present is not None:
+            presence["MS-GF+"] = bool(msgf_present)
     psm_metavalues = impute_union_features(psm_metavalues, worst, orientation)
     psm_metavalues, _ = add_engine_source_features(
-        psm_metavalues, comet_present=comet_present, msgf_present=msgf_present
+        psm_metavalues, presence=presence, engine_labels=labels
     )
     return psm_metavalues
 
 
-def union_feature_names(orientation: Optional[Dict[str, bool]] = None) -> Set[str]:
+def union_feature_names(
+    orientation: Optional[Dict[str, Optional[bool]]] = None,
+    engine_labels: Optional[Sequence[str]] = None,
+) -> Set[str]:
     """All Percolator feature names this module guarantees on every merged PSM."""
     if orientation is None:
-        orientation = UNION_FEATURE_ORIENTATION
-    return set(orientation) | {CONSENSUS_COMET_FEATURE, CONSENSUS_MSGF_FEATURE}
+        orientation = (
+            union_feature_orientation(engine_labels)
+            if engine_labels
+            else UNION_FEATURE_ORIENTATION
+        )
+    return set(orientation) | indicator_names(engine_labels)

--- a/quantmsrescore/idparquet_reader.py
+++ b/quantmsrescore/idparquet_reader.py
@@ -496,15 +496,35 @@ class ParquetRescoringReader(ParquetReader):
         # The curated feature orientations only cover Comet and MS-GF+, so any
         # other engine combination keeps the primary-score fill implemented in
         # ``fill_search_scores``.
-        if self._is_comet_msgf_merge():
+        if self._is_supported_consensus_merge():
             self._apply_consensus_features()
             self.consensus_features_applied = True
+        elif len(self.parquet_dirs) > 1:
+            unknown = sorted(set(self.merge_search_engines) - consensus_features.supported_engines())
+            logger.warning(
+                "Multi-engine merge with unsupported engine(s) %s: falling back to the "
+                "primary-score fill. This collapses the Percolator feature table to the "
+                "raw scores and imputes the missing engine with a single global constant, "
+                "which can make protein-level FDR unreachable. Supported engines: %s.",
+                ", ".join(unknown) or "<none>",
+                ", ".join(sorted(consensus_features.supported_engines())),
+            )
 
         self._log_spectrum_statistics()
 
-    def _is_comet_msgf_merge(self) -> bool:
-        """True for a merged run whose engines are exactly Comet + MS-GF+."""
-        return len(self.parquet_dirs) > 1 and set(self.merge_search_engines) == {"Comet", "MS-GF+"}
+    def _is_supported_consensus_merge(self) -> bool:
+        """True for a merged run whose engines are ALL in the consensus registry.
+
+        Deliberately a subset test rather than equality: any registered
+        combination (comet+msgf, comet+sage, msgf+sage, comet+msgf+sage) gets
+        the union feature treatment. An unregistered engine disables the path
+        entirely, because we would otherwise impute only the known engines'
+        features and leave the unknown engine's features missing on every other
+        engine's PSMs -- exactly the defect this module exists to prevent.
+        """
+        return len(self.parquet_dirs) > 1 and consensus_features.is_supported_engine_set(
+            self.merge_search_engines
+        )
 
     def _apply_consensus_features(self) -> None:
         """Add the union feature set + worst-case imputation + engine indicators
@@ -521,35 +541,60 @@ class ParquetRescoringReader(ParquetReader):
             return
         metavalue_col = self._psms_df["psm_metavalues"]
 
+        engines = list(self.merge_search_engines)
+        orientation = consensus_features.union_feature_orientation(engines)
+
         # Pass 1: worst-case per feature from real (pre-imputation) values.
         worst: Dict[str, float] = {}
         for mvs in metavalue_col:
-            consensus_features.update_worst_case(mvs, worst)
+            consensus_features.update_worst_case(mvs, worst, orientation)
 
-        comet_expect_fallback = (
-            self.max_comet_expectation_value
-            if np.isfinite(self.max_comet_expectation_value)
-            else worst.get("MS:1002257", 0.0)
-        )
+        score_fallback = self._sentinel_score_fallback(engines, worst)
 
         # Pass 2: impute missing-engine features + indicators; fix inf score.
         new_metavalues = []
         scores = self._psms_df["score"].tolist() if "score" in self._psms_df else None
         fixed_scores = []
         for idx, mvs in enumerate(metavalue_col):
-            comet_present, msgf_present = consensus_features.detect_engine_sources(mvs)
+            presence = consensus_features.detect_engines(mvs, engine_labels=engines)
             mvs = consensus_features.build_consensus_features(
-                mvs, worst, comet_present=comet_present, msgf_present=msgf_present
+                mvs, worst, orientation=orientation, presence=presence
             )
             new_metavalues.append(mvs)
             if scores is not None:
                 s = scores[idx]
-                fixed_scores.append(comet_expect_fallback if (s is None or not np.isfinite(s)) else s)
+                fixed_scores.append(score_fallback if (s is None or not np.isfinite(s)) else s)
         self._psms_df["psm_metavalues"] = new_metavalues
         if scores is not None:
             self._psms_df["score"] = fixed_scores
 
-        self._set_extra_features(consensus_features.union_feature_names())
+        self._set_extra_features(
+            consensus_features.union_feature_names(orientation, engine_labels=engines)
+        )
+
+    def _sentinel_score_fallback(self, engines, worst) -> float:
+        """Finite replacement for the ``score == inf`` sentinel on PSMs that the
+        score-owning engine did not identify.
+
+        ``score`` carries whichever engine's primary score the merger chose, in
+        the documented precedence Comet > MS-GF+ > Sage, so the fallback follows
+        the same order and uses that engine's worst observed primary. Falls back
+        to the accumulated per-feature worst when the reader-level statistic was
+        never populated (no PSM from that engine).
+        """
+        candidates = (
+            ("Comet", self.max_comet_expectation_value, "MS:1002257"),
+            ("MS-GF+", self.max_msgf_EValue, "MS:1002052"),
+            ("Sage", self.min_sage_hyperscore, "ln(hyperscore)"),
+        )
+        for label, stat, feature in candidates:
+            if label not in engines:
+                continue
+            if stat is not None and np.isfinite(stat):
+                return stat
+            if feature in worst:
+                return worst[feature]
+        return 0.0
 
     def _set_extra_features(self, feature_names) -> None:
         """Union ``feature_names`` into the ``extra_features`` search parameter."""

--- a/tests/test_consensus_features.py
+++ b/tests/test_consensus_features.py
@@ -167,3 +167,150 @@ class TestUnionFeatureNames:
         # no string/categorical metavalues leak in
         assert "protein_references" not in names
         assert "AssumedDissociationMethod" not in names
+
+
+# ---------------------------------------------------------------------------
+# SAGE / N-engine coverage (bigbio/quantms#717)
+#
+# Before the registry refactor the consensus path was gated on the engine set
+# being exactly {Comet, MS-GF+}, so every SAGE-involving merge silently fell
+# back to the primary-score fill -- including comet,msgf,sage, which meant
+# adding SAGE to a working two-engine run regressed it to the collapsed feature
+# table that returns zero proteins at 1% protein FDR.
+# ---------------------------------------------------------------------------
+
+# A sage-only PSM carries sage markers + sage features.
+SAGE_ONLY = [_mv("SAGE:matched_peaks", "14", "int"), _mv("SAGE:longest_b", "6", "int"),
+             _mv("SAGE:longest_y", "8", "int"), _mv("SAGE:ln(delta_next)", "1.4"),
+             _mv("ln(hyperscore)", "3.2"), _mv("SAGE:scored_candidates", "500", "int")]
+COMET_SAGE = ("Comet", "Sage")
+MSGF_SAGE = ("MS-GF+", "Sage")
+ALL_THREE = ("Comet", "MS-GF+", "Sage")
+
+
+class TestEngineRegistry:
+    def test_sage_is_registered(self):
+        assert "Sage" in CF.supported_engines()
+        assert CF.ENGINE_REGISTRY["Sage"].indicator == "CONSENSUS:sage"
+
+    def test_all_registered_combinations_are_supported(self):
+        for engines in (("Sage",), COMET_SAGE, MSGF_SAGE, ALL_THREE,
+                        ("Comet", "MS-GF+")):
+            assert CF.is_supported_engine_set(engines), engines
+
+    def test_unknown_engine_disables_consensus_path(self):
+        # An unregistered engine must switch the whole merge off rather than
+        # produce a union that silently omits its features.
+        assert not CF.is_supported_engine_set(("Comet", "Andromeda"))
+        assert not CF.is_supported_engine_set([])
+
+
+class TestSageDetection:
+    def test_sage_only(self):
+        found = CF.detect_engines(SAGE_ONLY, engine_labels=ALL_THREE)
+        assert found == {"Comet": False, "MS-GF+": False, "Sage": True}
+
+    def test_comet_plus_sage(self):
+        found = CF.detect_engines(COMET_ONLY + SAGE_ONLY, engine_labels=COMET_SAGE)
+        assert found == {"Comet": True, "Sage": True}
+
+    def test_msgf_plus_sage(self):
+        found = CF.detect_engines(MSGF_ONLY + SAGE_ONLY, engine_labels=MSGF_SAGE)
+        assert found == {"MS-GF+": True, "Sage": True}
+
+    def test_three_engine_single_engine_subsets(self):
+        for mvs, expect in ((COMET_ONLY, "Comet"), (MSGF_ONLY, "MS-GF+"), (SAGE_ONLY, "Sage")):
+            found = CF.detect_engines(mvs, engine_labels=ALL_THREE)
+            assert found[expect] is True
+            assert sum(found.values()) == 1, found
+
+    def test_imputed_sage_primary_does_not_count_as_presence(self):
+        # ln(hyperscore) is imputed onto non-sage PSMs, so it must NOT be a
+        # presence marker -- otherwise every PSM looks sage-identified.
+        imputed = COMET_ONLY + [_mv("ln(hyperscore)", "0.01")]
+        found = CF.detect_engines(imputed, engine_labels=COMET_SAGE)
+        assert found == {"Comet": True, "Sage": False}
+
+
+class TestSageImputation:
+    def test_sage_features_imputed_on_comet_only_psm(self):
+        orientation = CF.union_feature_orientation(COMET_SAGE)
+        worst = {}
+        for mvs in (COMET_ONLY, SAGE_ONLY):
+            CF.update_worst_case(mvs, worst, orientation)
+        out = CF.impute_union_features(list(COMET_ONLY), worst, orientation)
+        names = {m["name"] for m in out}
+        # every sage feature is now defined on a comet-only PSM
+        assert set(CF.SAGE_FEATURE_ORIENTATION).issubset(names)
+
+    def test_orientation_aware_worst_for_sage(self):
+        orientation = CF.union_feature_orientation(("Sage",))
+        worst = {}
+        CF.update_worst_case([_mv("SAGE:matched_peaks", "20")], worst, orientation)
+        CF.update_worst_case([_mv("SAGE:matched_peaks", "5")], worst, orientation)
+        # higher-is-better -> worst is the minimum
+        assert worst["SAGE:matched_peaks"] == 5.0
+
+    def test_unordered_feature_uses_midpoint_not_an_extreme(self):
+        # scored_candidates has no confidence ordering; imputing either extreme
+        # would assert a signal we have not measured.
+        orientation = CF.union_feature_orientation(("Sage",))
+        worst = {}
+        for v in ("100", "300", "500"):
+            CF.update_worst_case([_mv("SAGE:scored_candidates", v)], worst, orientation)
+        assert CF.SAGE_FEATURE_ORIENTATION["SAGE:scored_candidates"] is None
+        assert worst["SAGE:scored_candidates"] == 300.0  # midpoint of [100, 500]
+
+    def test_no_inf_or_nan_leaks_into_imputed_values(self):
+        orientation = CF.union_feature_orientation(ALL_THREE)
+        worst = {}
+        for mvs in (COMET_ONLY, MSGF_ONLY, SAGE_ONLY):
+            CF.update_worst_case(mvs, worst, orientation)
+        for mvs in (COMET_ONLY, MSGF_ONLY, SAGE_ONLY):
+            out = CF.build_consensus_features(
+                list(mvs), worst, orientation=orientation,
+                presence=CF.detect_engines(mvs, engine_labels=ALL_THREE))
+            for item in out:
+                value = float(item["value"])
+                assert value == value, item          # not NaN
+                assert abs(value) != float("inf"), item
+
+
+class TestSageIndicators:
+    def test_three_indicators_present_and_consistent(self):
+        orientation = CF.union_feature_orientation(ALL_THREE)
+        worst = {}
+        for mvs in (COMET_ONLY, MSGF_ONLY, SAGE_ONLY):
+            CF.update_worst_case(mvs, worst, orientation)
+        out = CF.build_consensus_features(
+            list(SAGE_ONLY), worst, orientation=orientation,
+            presence=CF.detect_engines(SAGE_ONLY, engine_labels=ALL_THREE))
+        flags = {m["name"]: m["value"] for m in out if m["name"].startswith("CONSENSUS:")}
+        assert flags == {"CONSENSUS:comet": "0", "CONSENSUS:msgf": "0", "CONSENSUS:sage": "1"}
+
+    def test_union_feature_names_cover_sage_and_all_indicators(self):
+        names = CF.union_feature_names(engine_labels=ALL_THREE)
+        assert set(CF.SAGE_FEATURE_ORIENTATION).issubset(names)
+        assert {"CONSENSUS:comet", "CONSENSUS:msgf", "CONSENSUS:sage"}.issubset(names)
+
+    def test_every_declared_feature_is_defined_on_every_psm(self):
+        # The contract that makes the merge safe: whatever we declare in
+        # extra_features must exist on EVERY merged PSM, whichever engine found it.
+        orientation = CF.union_feature_orientation(ALL_THREE)
+        declared = CF.union_feature_names(orientation, engine_labels=ALL_THREE)
+        worst = {}
+        for mvs in (COMET_ONLY, MSGF_ONLY, SAGE_ONLY):
+            CF.update_worst_case(mvs, worst, orientation)
+        for mvs in (COMET_ONLY, MSGF_ONLY, SAGE_ONLY, COMET_ONLY + SAGE_ONLY):
+            out = CF.build_consensus_features(
+                list(mvs), worst, orientation=orientation,
+                presence=CF.detect_engines(mvs, engine_labels=ALL_THREE))
+            names = {m["name"] for m in out}
+            assert declared.issubset(names), declared - names
+
+    def test_two_engine_default_unchanged_by_sage_support(self):
+        # Regression guard: the comet+msgf union validated on MSV000085836 must
+        # not silently gain sage features when sage is not configured.
+        names = CF.union_feature_names()
+        assert "CONSENSUS:sage" not in names
+        assert not any(n.startswith("SAGE:") for n in names)


### PR DESCRIPTION
Closes the SAGE gap tracked in [bigbio/quantms#717](https://github.com/bigbio/quantms/issues/717).

## The problem

The consensus path from #82 was gated on the engine set being **exactly** `{Comet, MS-GF+}`:

```python
return len(self.parquet_dirs) > 1 and set(self.merge_search_engines) == {"Comet", "MS-GF+"}
```

That was a deliberate, documented scope limit — but the consequence is that **every SAGE-involving merge runs the legacy `fill_search_scores` path**, i.e. the exact code that produced "No proteins left after FDR filtering" (EPIFANY exit 8) on MSV000085836: the feature table collapses to the raw primaries, and the missing engine is imputed with one global constant.

**The dangerous case is `comet,msgf,sage`.** Because the gate was exact set equality, adding SAGE to a *working* two-engine run silently dropped it back to the broken path — adding an engine made results worse, not better, with no error or warning. `nextflow_schema.json` advertises comet/msgf/sage as combinable, so this is reachable by following the documentation.

| config | before | after |
|---|---|---|
| `sage` | not a merge — unaffected | unchanged |
| `comet,msgf` | union (validated) | unchanged |
| `comet,sage` | legacy collapse | **union** |
| `msgf,sage` | legacy collapse | **union** |
| `comet,msgf,sage` | **silent regression** | **union** |
| any unregistered engine | legacy, silent | legacy, **warns** |

## The change

Replaces the hardcoded two-engine logic with an `EngineSpec` registry. Adding an engine is now one entry: presence markers + a curated numeric feature→orientation map. The gate becomes a **subset** test.

An unregistered engine still disables the path — deliberately. Imputing only the known engines' features would leave the unknown engine's features missing on every other engine's PSMs, which is the original defect in a new costume. It now logs a warning explaining the consequence instead of failing silently.

### Orientation gains a third state

`True`/`False` impute the worst observed value as before. **`None` means the feature has no confidence ordering** and is imputed to the *midpoint* of its observed range.

This exists for Sage's `scored_candidates`, which describes the spectrum's search space rather than match quality. Imputing either extreme would assert a signal we have not measured, and a wrong guess silently fills the *best* value for missing PSMs. The other six Sage features (`matched_peaks`, `longest_b`, `longest_y`, `longest_y_pct`, `ln(delta_next)`, `ln(matched_intensity_pct)`) plus the `ln(hyperscore)` primary are unambiguously higher-is-better.

**This is the one judgement call worth a reviewer's eye.** If someone has empirical evidence for a `scored_candidates` direction, changing `None` to a bool is a one-line edit.

### Score sentinel fallback

Also generalized: it followed Comet's expectation value unconditionally, which is wrong for a `msgf,sage` merge with no Comet at all. It now walks the documented `Comet > MS-GF+ > Sage` precedence and takes that engine's worst observed primary.

## Backwards compatibility

The two-engine API is preserved deliberately — `detect_engine_sources()` still returns the `(comet, msgf)` tuple and the `comet_present`/`msgf_present` keywords still work. **All 18 existing tests pass unchanged.** `union_feature_names()` with no arguments still yields exactly the comet+msgf set validated on MSV000085836, and there's a regression test asserting no SAGE feature leaks into it.

## Tests

16 new tests (34 total, all passing) covering sage-only, comet+sage, msgf+sage and the three-engine merge:

- registry membership and the unknown-engine guard
- engine detection for every single-engine subset of a three-engine merge
- imputed `ln(hyperscore)` does **not** count as SAGE presence (otherwise every PSM looks sage-identified)
- orientation-aware worst for SAGE; midpoint for the unordered feature
- no `inf`/`NaN` leaks into any imputed value
- all three indicators present and consistent
- **every feature declared in `extra_features` is defined on every merged PSM** — the contract that makes the merge safe

## Verification status

`consensus_features.py` is dependency-free by design, so its 34 tests run and pass locally. The `idparquet_reader.py` integration needs the full pyopenms/ms2rescore chain, which I could not build locally — **that layer is CI-verified only**, and worth a careful look during review. I have not run an end-to-end SAGE dataset; the acceptance criterion in #717 about a 1% protein-FDR benchmark vs a single-engine SAGE baseline is **not** covered here and should be a separate validation run.
