### PR TITLE
fix(consensus): derive feature orientation from the configured engines

### DIFF
--- a/quantmsrescore/consensus_features.py
+++ b/quantmsrescore/consensus_features.py
@@ -429,6 +429,14 @@ def build_consensus_features(
     the missing engines' features, so it must not be used as a presence signal).
     """
     labels = list(presence) if presence else (list(engine_labels) if engine_labels else None)
+    # Derive the orientation from the configured engines when the caller did not
+    # supply one. Without this, asking for e.g. ("Comet","MS-GF+","Sage") while
+    # omitting `orientation` emitted the CONSENSUS:sage indicator but imputed
+    # only the default Comet/MS-GF+ union, leaving every Sage feature declared in
+    # extra_features yet undefined on non-Sage PSMs -- the exact missing-value
+    # defect this module exists to prevent.
+    if orientation is None and labels:
+        orientation = union_feature_orientation(labels)
     if presence is None:
         detected = detect_engines(psm_metavalues, engine_labels=labels)
         presence = dict(detected)

--- a/quantmsrescore/idparquet_reader.py
+++ b/quantmsrescore/idparquet_reader.py
@@ -101,9 +101,9 @@ class ParquetRescoringReader(ParquetReader):
         self.min_comet_xcorr = np.inf
         self.min_sage_hyperscore = np.inf
         self.merge_search_engines = []  # Comet > MSGF > Sage
-        # True once the two-engine (comet + msgf) consensus feature union has
-        # been built for this run; downstream writers (annotator,
-        # psm_feature_clean) must then not re-impute / collapse the features.
+        # True once the multi-engine consensus feature union has actually been
+        # built for this run; downstream writers (annotator, psm_feature_clean)
+        # must then not re-impute / collapse the features.
         self.consensus_features_applied = False
 
         self._psms: Optional[PSMList] = None
@@ -493,12 +493,16 @@ class ParquetRescoringReader(ParquetReader):
         # imputation + engine-source indicators) so BOTH the ms2features-off path
         # (psm_feature_clean -> this reader) and the ms2features-on path
         # (annotator) produce an engine-aware, non-collapsed representation.
-        # The curated feature orientations only cover Comet and MS-GF+, so any
-        # other engine combination keeps the primary-score fill implemented in
-        # ``fill_search_scores``.
+        # Any merge whose engines are all in the consensus registry gets the union
+        # treatment; a combination containing an unregistered engine keeps the
+        # primary-score fill implemented in ``fill_search_scores``.
+        #
+        # The flag must reflect whether the transform actually ran: it is what
+        # tells ``psm_clean`` to skip ``fill_search_scores`` AND to skip writing
+        # extra_features. Setting it unconditionally would, for an empty PSM
+        # frame, suppress both and emit no extra_features at all.
         if self._is_supported_consensus_merge():
-            self._apply_consensus_features()
-            self.consensus_features_applied = True
+            self.consensus_features_applied = self._apply_consensus_features()
         elif len(self.parquet_dirs) > 1:
             unknown = sorted(set(self.merge_search_engines) - consensus_features.supported_engines())
             logger.warning(
@@ -526,7 +530,7 @@ class ParquetRescoringReader(ParquetReader):
             self.merge_search_engines
         )
 
-    def _apply_consensus_features(self) -> None:
+    def _apply_consensus_features(self) -> bool:
         """Add the union feature set + worst-case imputation + engine indicators
         to every merged PSM and record it in ``extra_features``.
 
@@ -538,7 +542,7 @@ class ParquetRescoringReader(ParquetReader):
         path never writes an infinite score.
         """
         if self._psms_df is None or self._psms_df.empty:
-            return
+            return False
         metavalue_col = self._psms_df["psm_metavalues"]
 
         engines = list(self.merge_search_engines)
@@ -571,6 +575,7 @@ class ParquetRescoringReader(ParquetReader):
         self._set_extra_features(
             consensus_features.union_feature_names(orientation, engine_labels=engines)
         )
+        return True
 
     def _sentinel_score_fallback(self, engines, worst) -> float:
         """Finite replacement for the ``score == inf`` sentinel on PSMs that the

--- a/tests/test_consensus_features.py
+++ b/tests/test_consensus_features.py
@@ -314,3 +314,46 @@ class TestSageIndicators:
         names = CF.union_feature_names()
         assert "CONSENSUS:sage" not in names
         assert not any(n.startswith("SAGE:") for n in names)
+
+
+class TestOrientationDefaultsFollowEngineLabels:
+    """Regression: build_consensus_features must not emit an engine's indicator
+    while leaving that engine's features undefined.
+
+    Passing engine_labels without an explicit orientation used to fall back to
+    the Comet/MS-GF+ default union, so a three-engine call emitted
+    CONSENSUS:sage but imputed no SAGE feature -- every SAGE name ended up
+    declared in extra_features yet missing on non-SAGE PSMs, which is the
+    missing-value defect the module exists to prevent.
+    """
+
+    def test_engine_labels_alone_impute_that_engines_features(self):
+        orientation = CF.union_feature_orientation(ALL_THREE)
+        worst = {}
+        for mvs in (COMET_ONLY, MSGF_ONLY, SAGE_ONLY):
+            CF.update_worst_case(mvs, worst, orientation)
+
+        # NOTE: orientation deliberately omitted -- derived from engine_labels.
+        out = CF.build_consensus_features(list(COMET_ONLY), worst, engine_labels=ALL_THREE)
+        names = {m["name"] for m in out}
+        declared = CF.union_feature_names(engine_labels=ALL_THREE)
+        assert declared.issubset(names), declared - names
+
+    def test_presence_alone_also_derives_orientation(self):
+        orientation = CF.union_feature_orientation(ALL_THREE)
+        worst = {}
+        for mvs in (COMET_ONLY, MSGF_ONLY, SAGE_ONLY):
+            CF.update_worst_case(mvs, worst, orientation)
+        presence = CF.detect_engines(COMET_ONLY, engine_labels=ALL_THREE)
+        out = CF.build_consensus_features(list(COMET_ONLY), worst, presence=presence)
+        names = {m["name"] for m in out}
+        assert CF.union_feature_names(engine_labels=ALL_THREE).issubset(names)
+
+    def test_no_labels_still_defaults_to_two_engine_union(self):
+        worst = {}
+        for mvs in (COMET_ONLY, MSGF_ONLY):
+            CF.update_worst_case(mvs, worst)
+        out = CF.build_consensus_features(list(COMET_ONLY), worst)
+        names = {m["name"] for m in out}
+        assert CF.union_feature_names().issubset(names)
+        assert not any(n.startswith("SAGE:") for n in names)


### PR DESCRIPTION
Two defects found while running a CodeRabbit review over the 0.0.22 release PR (#86). Targets `dev` so #86 picks them up.

## 1. Engine indicator emitted without that engine's features (major)

`build_consensus_features()` accepts `engine_labels` and `orientation` independently. Passing the former while omitting the latter fell back to the default Comet/MS-GF+ union — so a three-engine call produced this:

```
indicators present: CONSENSUS:comet, CONSENSUS:msgf, CONSENSUS:sage
declared in extra_features but UNDEFINED on non-Sage PSMs:
  ln(hyperscore), SAGE:matched_peaks, SAGE:longest_b, SAGE:longest_y,
  SAGE:longest_y_pct, SAGE:ln(delta_next),
  SAGE:ln(matched_intensity_pct), SAGE:scored_candidates
```

`CONSENSUS:sage` asserts Sage is configured while every Sage feature is missing from the PSM. That is the declared-but-undefined defect this module exists to prevent — the same shape as the original two-engine bug, just reached through a different door.

**No production path was affected**: `_apply_consensus_features` always passes an explicit `orientation`. But it is a trap for any caller using the natural `engine_labels` API, including a future simplification of that very call site.

Orientation is now derived from the configured labels when the caller omits it.

## 2. `consensus_features_applied` set on a no-op (minor)

`_apply_consensus_features()` returns early on an empty PSM frame, but the caller set the flag `True` unconditionally. That flag tells `psm_clean` to skip **both** `fill_search_scores` and the `extra_features` write — so an empty frame emitted no `extra_features` at all. The method now returns whether it actually ran, and the caller assigns that.

This pattern predates the SAGE work; it was carried over unchanged in #85.

## Stale comments

Two comments that #85 made obsolete and which now actively mislead a reader:

- `idparquet_reader.py` still said "the curated feature orientations only cover Comet and MS-GF+" — the entire point of #85 is that they no longer do.
- the `consensus_features_applied` docstring still described itself as two-engine specific.

## Tests

37 passing (3 new). The added cases cover `engine_labels` alone, `presence` alone, and — importantly — that the **no-argument default still yields exactly the comet+msgf union validated on MSV000085836**, so this fix cannot quietly widen the feature set of the configuration that has production evidence behind it.

## Not addressed here

CodeRabbit also flagged three documentation inaccuracies in the other half of #86 (README Feature Validation omits AlphaPeptDeep; README implies SAGE features live in `search_params.parquet` when they are PSM-level; `model_downloader.py` help text omits its actual `ms2pip,alphapeptdeep` default). Left out to keep this PR to the consensus-logic fix — happy to send them separately.
