### PR TITLE
fix: address CodeRabbit review comments on the 0.0.22 release PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Unlike traditional rescoring approaches, quantms-rescoring incorporates advanced
 
 ## Technical Implementation Details
 
-#### Model Selection and Optimization
+### Model Selection and Optimization
 
 - **MS2PIP Model Selection**:
   - Automatically evaluate the quality of the MS2PIP model selected by the user. If the correlation between predicted and experimental spectra is lower than a given threshold, we will try to find the best model to use (`annotator.py`). For example, if the user provides as model parameter HCD for a CI experiment, the tool will try to find the best model for this experiment within the CID models available.
@@ -117,7 +117,7 @@ Unlike traditional rescoring approaches, quantms-rescoring incorporates advanced
   - Calculates spectral entropy to quantify peak distribution uniformity
   - Analyzes TIC (Total Ion Current) distribution across peaks for quality assessment
   - Determines weighted standard deviation of m/z values for spectral complexity estimation
-- **Feature Selection**: The parameters `only_features` allows to select the features to be added to the idparquet file. For example: `--only_features "DeepLC:RtDiff,DeepLC:PredictedRetentionTimeBest,Ms2pip:DotProd"`.
+- **Feature Selection**: The parameters `only_features` allows to select the features to be added to the idparquet file. For example: `--only_features "rt_diff,predicted_retention_time_best,dotprod"`.
 
 #### Features
 
@@ -229,10 +229,10 @@ Unlike traditional rescoring approaches, quantms-rescoring incorporates advanced
 
 - **Parallel Processing**: Implements multiprocessing capabilities for handling large datasets efficiently
 - **OpenMS Compatibility Layer**: Custom helper classes that gather statistics of number of PSMs by MS levels / dissociation methods, etc.
-- **Feature Validation**: Convert all Features from MS2PIP, DeepLC, and quantms into OpenMS features with well-established names (`constants.py`)
+- **Feature Validation**: Convert all Features from MS2PIP, AlphaPeptDeep, DeepLC, and quantms into OpenMS features with well-established names (`constants.py`)
 - **PSM Filtering and Validation**:
   - Filter PSMs with **missing spectra information** or **empty peaks**.
-  - Breaks the analysis of the input file contains more than one MS level or dissociation method, **only support for MS2 level** spectra.
+  - Aborts processing when the input contains more than one MS level or dissociation method; **only MS2 spectra are supported**.
 - **Multi-Engine Consensus Rescoring**: When multiple idparquet directories from different search engines (Comet, MS-GF+, Sage) are provided, the tool merges them in priority order (`Comet > MS-GF+ > Sage`), fills missing scores for each engine, and marks the result as `quantms-consensus-rescoring`.
 - **Output / Input files**:
   - Input is an `.idparquet` directory containing `psms.parquet`, `proteins.parquet`, `protein_groups.parquet`, and `search_params.parquet`, along with a companion `.mzML` spectrum file.

--- a/quantmsrescore/consensus_features.py
+++ b/quantmsrescore/consensus_features.py
@@ -327,6 +327,15 @@ def update_worst_case(
             value = float(raw)
         except (TypeError, ValueError):
             continue
+        # ``float()`` happily parses "inf"/"-inf"/"nan", and a single degenerate
+        # metavalue (e.g. a -inf log-transformed score) would otherwise become
+        # THE worst-case constant and be written onto every missing-engine PSM.
+        # NaN is worse still: min()/max() propagate it depending on argument
+        # order, so one NaN can poison the accumulator for the whole run. The
+        # reader's np.isfinite repair only guards the `score` column, not
+        # features, so this is the only place it can be caught.
+        if value != value or value in (float("inf"), float("-inf")):
+            continue
         if higher_better is None:
             lo_key, hi_key = name + _MIN_SUFFIX, name + _MAX_SUFFIX
             lo = min(worst.get(lo_key, value), value)

--- a/quantmsrescore/idparquet_reader.py
+++ b/quantmsrescore/idparquet_reader.py
@@ -571,11 +571,30 @@ class ParquetRescoringReader(ParquetReader):
         self._psms_df["psm_metavalues"] = new_metavalues
         if scores is not None:
             self._psms_df["score"] = fixed_scores
+            self._repair_psmlist_scores(score_fallback)
 
         self._set_extra_features(
             consensus_features.union_feature_names(orientation, engine_labels=engines)
         )
         return True
+
+    def _repair_psmlist_scores(self, score_fallback: float) -> None:
+        """Mirror the sentinel repair from ``_psms_df`` onto the ``PSMList``.
+
+        The merger writes the ``inf`` sentinel to BOTH ``record["score"]`` (which
+        becomes ``_psms_df``) and ``psm.score`` (which becomes ``self._psms``),
+        but only the DataFrame was repaired. ``reader.psms`` is what the
+        annotator consumes -- ``_get_top_batch_psms`` sorts calibration
+        candidates by ``psm.score`` -- so leaving ``inf`` there means the two
+        views of the same PSM disagree, and for a higher-is-better score type
+        the sentinel PSMs sort to the FRONT of the calibration set.
+        """
+        if self._psms is None:
+            return
+        for psm in self._psms.psm_list:
+            score = getattr(psm, "score", None)
+            if score is None or not np.isfinite(score):
+                psm.score = score_fallback
 
     def _sentinel_score_fallback(self, engines, worst) -> float:
         """Finite replacement for the ``score == inf`` sentinel on PSMs that the
@@ -586,6 +605,12 @@ class ParquetRescoringReader(ParquetReader):
         the same order and uses that engine's worst observed primary. Falls back
         to the accumulated per-feature worst when the reader-level statistic was
         never populated (no PSM from that engine).
+
+        The last resort is derived from the finite scores actually present
+        rather than a constant: the score types in play (Comet ``expect``,
+        MS-GF+ ``SpecEValue``) are lower-is-better, so a literal ``0.0`` would
+        hand a PERFECT score to exactly the PSMs the score-owning engine never
+        identified -- the inverse of this module's worst-case intent.
         """
         candidates = (
             ("Comet", self.max_comet_expectation_value, "MS:1002257"),
@@ -599,7 +624,25 @@ class ParquetRescoringReader(ParquetReader):
                 return stat
             if feature in worst:
                 return worst[feature]
-        return 0.0
+        return self._worst_observed_score()
+
+    def _worst_observed_score(self) -> float:
+        """Direction-correct worst of the finite scores present in ``_psms_df``.
+
+        Lower-is-better score types take the maximum, higher-is-better the
+        minimum. Returns 0.0 only when no finite score exists at all, i.e. every
+        PSM carries the sentinel, in which case the run is degenerate anyway.
+        """
+        if self._psms_df is None or "score" not in self._psms_df:
+            return 0.0
+        finite = self._psms_df["score"][np.isfinite(self._psms_df["score"])]
+        if finite.empty:
+            logger.warning(
+                "No finite PSM score available to replace the merge sentinel; "
+                "falling back to 0.0. Every PSM appears to carry the sentinel."
+            )
+            return 0.0
+        return float(finite.min() if self.high_score_better else finite.max())
 
     def _set_extra_features(self, feature_names) -> None:
         """Union ``feature_names`` into the ``extra_features`` search parameter."""

--- a/quantmsrescore/model_downloader.py
+++ b/quantmsrescore/model_downloader.py
@@ -294,7 +294,7 @@ def download_alphapeptdeep_models(model_dir: Optional[Path] = None) -> None:
 )
 @click.option(
     "--models",
-    help="Comma-separated list of models to download: ms2pip, alphapeptdeep (default: all)",
+    help="Comma-separated list of models to download: ms2pip, alphapeptdeep (default: ms2pip,alphapeptdeep)",
     default="ms2pip,alphapeptdeep",
 )
 def download_models(model_dir: Optional[str], log_level: str, models: str) -> None:

--- a/tests/test_consensus_features.py
+++ b/tests/test_consensus_features.py
@@ -357,3 +357,59 @@ class TestOrientationDefaultsFollowEngineLabels:
         names = {m["name"] for m in out}
         assert CF.union_feature_names().issubset(names)
         assert not any(n.startswith("SAGE:") for n in names)
+
+
+class TestNonFiniteValuesAreRejected:
+    """Regression: float() parses "inf"/"-inf"/"nan", so a single degenerate
+    metavalue could become THE worst-case constant and be written onto every
+    missing-engine PSM. NaN was worse -- min()/max() propagate it depending on
+    argument order, so one NaN could poison the accumulator for a whole run.
+    The reader's np.isfinite repair only guards the `score` column, never
+    features, so update_worst_case is the only place this can be caught.
+    """
+
+    def test_negative_inf_does_not_become_the_worst_case(self):
+        worst = {}
+        CF.update_worst_case([_mv("COMET:xcorr", "2.0")], worst)
+        CF.update_worst_case([_mv("COMET:xcorr", "-inf")], worst)
+        assert worst["COMET:xcorr"] == 2.0
+
+    def test_positive_inf_ignored_for_lower_is_better(self):
+        worst = {}
+        CF.update_worst_case([_mv("MS:1002052", "1e-12")], worst)
+        CF.update_worst_case([_mv("MS:1002052", "inf")], worst)
+        assert worst["MS:1002052"] == 1e-12
+
+    def test_nan_does_not_poison_regardless_of_order(self):
+        # NaN first was the poisoning order: min(nan, x) returns nan.
+        worst = {}
+        CF.update_worst_case([_mv("COMET:xcorr", "nan")], worst)
+        CF.update_worst_case([_mv("COMET:xcorr", "2.0")], worst)
+        assert worst["COMET:xcorr"] == 2.0
+
+        worst2 = {}
+        CF.update_worst_case([_mv("COMET:xcorr", "2.0")], worst2)
+        CF.update_worst_case([_mv("COMET:xcorr", "nan")], worst2)
+        assert worst2["COMET:xcorr"] == 2.0
+
+    def test_unordered_feature_range_ignores_non_finite(self):
+        worst = {}
+        orientation = CF.union_feature_orientation(("Sage",))
+        for v in ("100", "inf", "500", "nan"):
+            CF.update_worst_case([_mv("SAGE:scored_candidates", v)], worst, orientation)
+        assert worst["SAGE:scored_candidates"] == 300.0  # midpoint of [100, 500]
+
+    def test_non_finite_never_reaches_imputed_metavalues(self):
+        orientation = CF.union_feature_orientation(ALL_THREE)
+        worst = {}
+        # a degenerate PSM for every engine
+        CF.update_worst_case(COMET_ONLY + [_mv("COMET:xcorr", "-inf")], worst, orientation)
+        CF.update_worst_case(MSGF_ONLY + [_mv("MS:1002049", "nan")], worst, orientation)
+        CF.update_worst_case(SAGE_ONLY + [_mv("SAGE:longest_b", "inf")], worst, orientation)
+        out = CF.build_consensus_features(
+            [], worst, orientation=orientation,
+            presence={"Comet": False, "MS-GF+": False, "Sage": False})
+        for item in out:
+            value = float(item["value"])
+            assert value == value, item                    # not NaN
+            assert abs(value) != float("inf"), item        # not +/-inf


### PR DESCRIPTION
Addresses all 8 CodeRabbit comments on the 0.0.22 release PR (#86). Targets `dev` so #86 picks them up. **I verified each against the code before acting — all 8 were valid.**

## Major 1 — non-finite values became the worst-case constant

`float()` happily parses `"inf"`, `"-inf"` and `"nan"`, so one degenerate metavalue became THE worst-case constant and was written onto every missing-engine PSM. Reproduced before fixing:

```
update_worst_case(COMET:xcorr = 2.0)
update_worst_case(COMET:xcorr = -inf)
-> worst["COMET:xcorr"] == -inf
-> imputed onto every PSM as the literal string "-inf"
```

NaN was worse and **order-dependent**: `min(nan, x)` returns `nan`, so a NaN seen before a real value poisoned the accumulator for the entire run, while the same NaN seen after was harmless. That is the kind of bug that reproduces on one dataset and not another.

The reader's `np.isfinite` repair only guards the `score` column, never features, so `update_worst_case` is the only place this can be caught. Non-finite values are now skipped.

## Major 2 — sentinel repair reached the DataFrame but not the PSMList

The merger writes the `inf` sentinel to **both** `record["score"]` (→ `_psms_df`) and `psm.score` (→ `self._psms`), but `_apply_consensus_features` only repaired the DataFrame.

`reader.psms` is what the annotator consumes: `_get_top_batch_psms` sorts calibration candidates with `sort(key=lambda x: x.score, reverse=self._higher_score_better)`. So the two views of the same PSM disagreed, and the impact depends on sort direction — for a higher-is-better score type the sentinel PSMs (the ones the score-owning engine never identified) sort to the **front** of the calibration set. Now mirrored onto the `PSMList`.

## Minor — last-resort fallback returned the *best* value

My `_sentinel_score_fallback` ended in `return 0.0`. Comet `expect` and MS-GF+ `SpecEValue` are both lower-is-better, so `0.0` is a *perfect* score — handed to exactly the PSMs that engine never identified, the inverse of this module's worst-case intent, and inconsistent with `psm_clean.fill_search_scores`.

Now derived from the finite scores actually present and direction-aware via `high_score_better` (max for lower-is-better, min for higher-is-better), with `0.0` reachable only when no finite score exists at all — a degenerate run, and it warns.

## Minor — documentation (5)

- `--models` help said `default: all` while the default is `ms2pip,alphapeptdeep`
- README heading jumped `h2 → h4` (MD001)
- **the `only_features` example did not work**: `"Ms2pip:DotProd"` is neither a canonical key (`MS2PIP:DotProd`) nor an accepted value — `validate_features()` matches only `MS2PIP_FEATURES.values()`, so the documented example warned and silently filtered nothing. Changed to accepted values (`rt_diff,predicted_retention_time_best,dotprod`)
- Feature Validation inventory omitted AlphaPeptDeep
- the MS-level bullet did not say whether processing aborts or filters

On the `only_features` one, CodeRabbit offered two routes: fix the docs, or make `validate_features` accept canonical keys too. I took the documentation route to keep a release PR to documented-reality. Accepting keys as well is friendlier UX (`MS2PIP:DotProd` is far more readable than `dotprod`) and is strictly additive — happy to send that separately if you want it.

## Tests

42 passing (5 new), including the `inf`/`nan` metavalue case CodeRabbit asked for, plus the NaN-ordering case in both directions.

**Verification limit, unchanged from #85:** `consensus_features.py` is dependency-free so its tests run locally, but the `idparquet_reader` changes — including the new `_repair_psmlist_scores` — need the full pyopenms chain and are **CI-verified only**. The PSMList repair in particular deserves review attention since I could not exercise it locally.
