### PR TITLE
fix(consensus): close 5 of 6 adversarial-review findings; Sage registry validated against a real SageAdapter run

### DIFF
--- a/quantmsrescore/consensus_features.py
+++ b/quantmsrescore/consensus_features.py
@@ -62,9 +62,15 @@ imputed to the worst value observed for that feature. ``None`` features are
 imputed to the *midpoint* of their observed range — a deliberately
 non-informative fill, because imputing an extreme for a feature that does not
 encode confidence would inject a false signal in whichever direction we
-guessed. This is used for Sage's ``scored_candidates`` (a property of the
-spectrum's search space, not of PSM quality), where an extreme fill in either
-direction would be an unjustified claim.
+guessed.
+
+No registry feature currently uses ``None``: Sage's ``scored_candidates`` was
+originally registered that way on first-principles reasoning (it describes the
+search space, not match quality), but measured target/decoy separation put it
+clearly in the higher-is-better direction, so it is registered as such. The
+mechanism is kept because it is the correct answer whenever a feature's
+direction genuinely cannot be established, and guessing would inject a signal
+that was never measured.
 """
 
 from __future__ import annotations
@@ -142,22 +148,50 @@ MSGF_FEATURE_ORIENTATION: Dict[str, Optional[bool]] = {
     "MeanErrorAll": False,
     "StdevErrorAll": False,
 }
-# Sage feature names as emitted into psm_metavalues by quantms (the ``psm_file``
-# rows of Sage's feature table; see ``sage_feature.py``). ``ln(hyperscore)`` is
-# the primary score and is written without the ``SAGE:`` prefix by the merger.
+# Sage features, taken from the metavalue names Sage actually emits and with
+# orientations derived from measured target/decoy separation rather than
+# guessed. Source: tests/test_data/..._sage_ms2rescore.idXML (5,755 PeptideHits,
+# 4,219 target / 1,463 decoy); mean target vs mean decoy per feature:
+#
+#   SAGE:ln(-poisson)               2.0962 vs 0.9212   -> higher better
+#   SAGE:ln(delta_next)             2.2498 vs 0.7155   -> higher better
+#   SAGE:ln(matched_intensity_pct)  2.8076 vs 1.8669   -> higher better
+#   SAGE:longest_b                  4.9682 vs 1.1080   -> higher better
+#   SAGE:longest_y                  4.8085 vs 1.2324   -> higher better
+#   SAGE:longest_y_pct              0.4014 vs 0.1369   -> higher better
+#   SAGE:matched_peaks             13.7516 vs 3.6104   -> higher better
+#   SAGE:scored_candidates        193.0092 vs 113.7204 -> higher better
+#
+# Deliberately NOT registered:
+#   ln(hyperscore)        Sage's primary score is NOT a metavalue at all -- it
+#                         lives in the `score` column (score_type="hyperscore",
+#                         higher_score_better="true"), exactly like Comet's
+#                         MS:1002257. Declaring it produced a feature no engine
+#                         emits. Consequence: in a merge where Sage is not the
+#                         dominant engine its primary score is currently lost;
+#                         the nine auxiliary features below still carry signal.
+#   SAGE:ln(delta_best)   Measured as exactly 0.0000 for BOTH targets and decoys
+#                         in the fixture, because quantms searches at
+#                         num_hits=1 and delta-to-best is 0 for a rank-1 hit. A
+#                         zero-variance feature carries no information, and its
+#                         sign convention cannot be established from constant
+#                         data, so it is left out rather than guessed at.
 SAGE_FEATURE_ORIENTATION: Dict[str, Optional[bool]] = {
-    "ln(hyperscore)": True,               # primary
+    "SAGE:ln(-poisson)": True,
     "SAGE:ln(delta_next)": True,          # bigger gap to the runner-up = better
     "SAGE:ln(matched_intensity_pct)": True,
     "SAGE:matched_peaks": True,
     "SAGE:longest_b": True,
     "SAGE:longest_y": True,
     "SAGE:longest_y_pct": True,
-    # Number of candidates scored for the spectrum. This describes the search
-    # space, not the quality of the match, so it has no confidence ordering:
-    # imputing either extreme would assert something we have not measured.
-    # Midpoint-imputed instead (see module docstring).
-    "SAGE:scored_candidates": None,
+    # Number of candidates scored for the spectrum. Reasoning from first
+    # principles this looks like a property of the search space rather than of
+    # match quality, which argued for an unordered (midpoint) fill -- but the
+    # measurement above separates targets from decoys clearly and consistently
+    # in the higher-is-better direction. Data wins over the prior, and it is
+    # also the more conservative choice: missing PSMs get the observed MINIMUM
+    # instead of a mid-range value.
+    "SAGE:scored_candidates": True,
 }
 
 ENGINE_REGISTRY: Dict[str, EngineSpec] = {
@@ -258,6 +292,24 @@ def _to_list(psm_metavalues) -> List:
     return list(psm_metavalues)
 
 
+def meta_map(psm_metavalues) -> Dict[str, object]:
+    """Build a ``{name: value}`` map for one PSM's metavalues.
+
+    Both the worst-case accumulation and the presence detection previously did a
+    linear scan of the metavalue list *per feature*, i.e. O(features x
+    metavalues) per PSM. On a production run (~6.6M PSMs, ~40 registry features,
+    ~25 metavalues each) that is billions of dict lookups. Building this map once
+    per PSM makes both passes O(metavalues) plus O(features) hash lookups.
+    """
+    out: Dict[str, object] = {}
+    for item in _to_list(psm_metavalues):
+        if isinstance(item, dict):
+            name = item.get("name")
+            if name is not None and name not in out:
+                out[name] = item.get("value")
+    return out
+
+
 def _has_meta(psm_metavalues, name: str) -> bool:
     for item in _to_list(psm_metavalues):
         if isinstance(item, dict) and item.get("name") == name:
@@ -275,6 +327,7 @@ def _meta_value(psm_metavalues, name: str):
 def detect_engines(
     psm_metavalues,
     engine_labels: Optional[Sequence[str]] = None,
+    values: Optional[Dict[str, object]] = None,
 ) -> Dict[str, bool]:
     """Detect which of the configured engines genuinely identified a PSM.
 
@@ -286,8 +339,9 @@ def detect_engines(
     dict
         engine label -> ``True``/``False``.
     """
+    names = set(values) if values is not None else set(meta_map(psm_metavalues))
     return {
-        spec.label: any(_has_meta(psm_metavalues, m) for m in spec.presence_markers)
+        spec.label: any(m in names for m in spec.presence_markers)
         for spec in _specs(engine_labels)
     }
 
@@ -305,6 +359,7 @@ def update_worst_case(
     psm_metavalues,
     worst: Dict[str, float],
     orientation: Optional[Dict[str, Optional[bool]]] = None,
+    values: Optional[Dict[str, object]] = None,
 ) -> Dict[str, float]:
     """Accumulate per-feature imputation constants in-place.
 
@@ -319,8 +374,10 @@ def update_worst_case(
     """
     if orientation is None:
         orientation = UNION_FEATURE_ORIENTATION
+    if values is None:
+        values = meta_map(psm_metavalues)
     for name, higher_better in orientation.items():
-        raw = _meta_value(psm_metavalues, name)
+        raw = values.get(name)
         if raw is None:
             continue
         try:

--- a/quantmsrescore/consensus_features.py
+++ b/quantmsrescore/consensus_features.py
@@ -354,24 +354,73 @@ def impute_union_features(
     worst: Dict[str, float],
     orientation: Optional[Dict[str, Optional[bool]]] = None,
 ) -> List:
-    """Ensure every union feature is defined on ``psm_metavalues``.
+    """Ensure every *constrained* union feature is defined on ``psm_metavalues``.
 
-    Any union feature missing from this PSM (i.e. belonging to an engine that
-    did not identify it) is filled with that feature's own constant from
-    ``worst``. Idempotent: features already present are left untouched.
+    A union feature missing from this PSM (i.e. belonging to an engine that did
+    not identify it) is filled with that feature's own constant from ``worst``.
+    Idempotent: features already present are left untouched.
+
+    A feature with NO observed imputation constant is deliberately left alone
+    rather than fabricated. The previous ``worst.get(name, 0.0)`` invented a
+    value that is the BEST possible one for every lower-is-better feature: the
+    registry declares Comet ``MS:1002257`` (expectation value), but Comet stores
+    its expectation in the ``score`` column and emits no such metavalue, so the
+    accumulator never saw it and every PSM was handed a perfect expectation.
+    Pair this with :func:`constrained_features` so the same features are the
+    ones advertised in ``extra_features``.
     """
     if orientation is None:
         orientation = UNION_FEATURE_ORIENTATION
     psm_metavalues = _to_list(psm_metavalues)
     present = {item.get("name") for item in psm_metavalues if isinstance(item, dict)}
-    for name in orientation:
+    for name in constrained_features(worst, orientation):
         if name in present:
             continue
-        value = worst.get(name, 0.0)
         psm_metavalues.append(
-            {"name": name, "value": repr(float(value)), "value_type": "double"}
+            {"name": name, "value": repr(float(worst[name])), "value_type": "double"}
         )
     return psm_metavalues
+
+
+def constrained_features(
+    worst: Dict[str, float],
+    orientation: Optional[Dict[str, Optional[bool]]] = None,
+) -> Set[str]:
+    """Union features that have a finite, observed imputation constant.
+
+    Only these can honour the contract that every name advertised in
+    ``extra_features`` is defined on every merged PSM. A declared feature that
+    no engine actually emits (a wrong or renamed metavalue key, an engine whose
+    primary score lives in the ``score`` column) has no defensible fill value,
+    so it is dropped from the advertised set instead of being invented.
+    """
+    if orientation is None:
+        orientation = UNION_FEATURE_ORIENTATION
+    out: Set[str] = set()
+    for name in orientation:
+        value = worst.get(name)
+        if value is None:
+            continue
+        try:
+            value = float(value)
+        except (TypeError, ValueError):
+            continue
+        if value != value or value in (float("inf"), float("-inf")):
+            continue
+        out.add(name)
+    return out
+
+
+def unconstrained_features(
+    worst: Dict[str, float],
+    orientation: Optional[Dict[str, Optional[bool]]] = None,
+) -> Set[str]:
+    """Declared features with no observed constant -- i.e. those dropped by
+    :func:`constrained_features`. Useful for logging what the registry claimed
+    but the data never provided."""
+    if orientation is None:
+        orientation = UNION_FEATURE_ORIENTATION
+    return set(orientation) - constrained_features(worst, orientation)
 
 
 def add_engine_source_features(
@@ -463,12 +512,23 @@ def build_consensus_features(
 def union_feature_names(
     orientation: Optional[Dict[str, Optional[bool]]] = None,
     engine_labels: Optional[Sequence[str]] = None,
+    worst: Optional[Dict[str, float]] = None,
 ) -> Set[str]:
-    """All Percolator feature names this module guarantees on every merged PSM."""
+    """All Percolator feature names this module guarantees on every merged PSM.
+
+    Pass ``worst`` (the accumulator from :func:`update_worst_case`) to get the
+    set that is ACTUALLY guaranteed: features the data never provided have no
+    imputation constant, are therefore not written onto missing-engine PSMs, and
+    must not be advertised to Percolator. Without ``worst`` this returns the
+    registry's nominal set, which is a superset.
+    """
     if orientation is None:
         orientation = (
             union_feature_orientation(engine_labels)
             if engine_labels
             else UNION_FEATURE_ORIENTATION
         )
-    return set(orientation) | indicator_names(engine_labels)
+    names = set(orientation) if worst is None else constrained_features(worst, orientation)
+    # Indicators are computed per PSM (0/1), never imputed, so they are always
+    # guaranteed regardless of what the engines emitted.
+    return names | indicator_names(engine_labels)

--- a/quantmsrescore/idparquet_reader.py
+++ b/quantmsrescore/idparquet_reader.py
@@ -38,6 +38,21 @@ now = datetime.now(timezone.utc)
 # run identifier
 run_identifier = f"quantms-rescoring_{now.strftime('%Y-%m-%d_%H:%M:%S')}"
 
+# Escape hatch for a multi-engine merge containing an engine the consensus
+# registry does not know. Off by default: the legacy fallback is a known-invalid
+# representation, so it must be an explicit, deliberate choice.
+ALLOW_LEGACY_MERGE_ENV = "QUANTMSRESCORE_ALLOW_LEGACY_MULTI_ENGINE"
+
+
+class UnsupportedEngineMergeError(ValueError):
+    """Raised when a multi-engine merge contains an unregistered search engine.
+
+    Failing here is deliberate: the only alternative path collapses the feature
+    table and has produced zero proteins at 1% protein FDR in production, so a
+    misspelled or newly added engine label must stop the run rather than quietly
+    degrade its statistics.
+    """
+
 
 class ScoreStats:
     """Statistics about score occurrence in peptide hits."""
@@ -453,27 +468,43 @@ class ParquetRescoringReader(ParquetReader):
                 psm_metavalues = row["psm_metavalues"].tolist()
                 self.get_default_scores(search_params, psm_metavalues, record)
                 if prov_key not in merged_psms:
+                    # Substituting the dominant engine's score type MUST also
+                    # carry that type's direction. A Sage row arrives as
+                    # score_type="hyperscore" with higher_score_better=true; if
+                    # only score_type is rewritten to the lower-is-better
+                    # "expect"/"SpecEValue", the row claims a lower-is-better
+                    # score with a higher-is-better flag, and everything
+                    # downstream that trusts row metadata to sort or compute
+                    # q-values inverts for those PSMs.
                     if len(set(self.merge_search_engines)) > 1:
                         if "Comet" in self.merge_search_engines and search_params["search_engine"] != "Comet":
                             psm.score = np.inf
                             record["score"] = np.inf
                             record["score_type"] = "expect"
+                            record["higher_score_better"] = False
                         elif "MS-GF+" in self.merge_search_engines and "Comet" not in self.merge_search_engines and search_params["search_engine"] != "MS-GF+":
                             psm.score = np.inf
                             record["score"] = np.inf
                             record["score_type"] = "SpecEValue"
+                            record["higher_score_better"] = False
                     merged_psms[prov_key] = copy.copy(psm)
                     record["psm_metavalues"] = psm_metavalues
                     merged_records[prov_key] = copy.copy(record)
                 else:
+                    # Same rule as above: whenever the stored score is replaced
+                    # by another engine's, its DIRECTION has to travel with it.
                     if search_params["search_engine"] == "Comet":
                         merged_psms[prov_key].score = psm.score
                         merged_records[prov_key]["score"] = psm.score
                         merged_records[prov_key]["score_type"] = row["score_type"]
+                        merged_records[prov_key]["higher_score_better"] = self._safe_get(
+                            row, ["higher_score_better"], False)
                     elif "Comet" not in self.merge_search_engines and search_params["search_engine"] == "MS-GF+":
                         merged_psms[prov_key].score = psm.score
                         merged_records[prov_key]["score"] = psm.score
                         merged_records[prov_key]["score_type"] = row["score_type"]
+                        merged_records[prov_key]["higher_score_better"] = self._safe_get(
+                            row, ["higher_score_better"], False)
 
                     merged_records[prov_key]["psm_metavalues"] = self.merge_dedup_metavalues(
                         merged_records[prov_key]["psm_metavalues"],
@@ -505,14 +536,22 @@ class ParquetRescoringReader(ParquetReader):
             self.consensus_features_applied = self._apply_consensus_features()
         elif len(self.parquet_dirs) > 1:
             unknown = sorted(set(self.merge_search_engines) - consensus_features.supported_engines())
-            logger.warning(
-                "Multi-engine merge with unsupported engine(s) %s: falling back to the "
-                "primary-score fill. This collapses the Percolator feature table to the "
-                "raw scores and imputes the missing engine with a single global constant, "
-                "which can make protein-level FDR unreachable. Supported engines: %s.",
-                ", ".join(unknown) or "<none>",
-                ", ".join(sorted(consensus_features.supported_engines())),
+            message = (
+                f"Multi-engine merge with unsupported search engine(s): "
+                f"{', '.join(unknown) or '<none>'}. The only fallback is the legacy "
+                f"primary-score fill, which collapses the Percolator feature table to the "
+                f"raw scores and imputes the missing engine with a single global constant; "
+                f"that representation is known to make protein-level FDR unreachable and "
+                f"has returned zero proteins from EPIFANY in production. "
+                f"Supported engines: {', '.join(sorted(consensus_features.supported_engines()))}. "
+                f"Set {ALLOW_LEGACY_MERGE_ENV}=1 to proceed anyway."
             )
+            # Fail before the expensive downstream analysis rather than emitting
+            # output from a representation we know to be invalid. A misspelled or
+            # newly added engine label should be loud, not silently degrading.
+            if os.environ.get(ALLOW_LEGACY_MERGE_ENV, "").strip().lower() not in ("1", "true", "yes"):
+                raise UnsupportedEngineMergeError(message)
+            logger.warning("%s Proceeding because %s is set.", message, ALLOW_LEGACY_MERGE_ENV)
 
         self._log_spectrum_statistics()
 
@@ -587,12 +626,67 @@ class ParquetRescoringReader(ParquetReader):
                 "metavalue names match what the engine emits.",
                 ", ".join(sorted(dropped)),
             )
-        self._set_extra_features(
-            consensus_features.union_feature_names(
-                orientation, engine_labels=engines, worst=worst
-            )
+
+        guaranteed = consensus_features.union_feature_names(
+            orientation, engine_labels=engines, worst=worst
         )
+        # Any pre-existing extra_features entry came from the PRIORITY engine's
+        # search params and is only kept if it is genuinely present on EVERY
+        # merged PSM. Comet advertises MS:1002252/MS:1002255 aliases and MS-GF+
+        # advertises MS:1002053 that its own PSMs do not carry; unioning those
+        # in would re-introduce engine-specific and outright absent names into
+        # the very table this path exists to make complete.
+        universal = self._names_on_every_psm(new_metavalues)
+        inherited = self._existing_extra_features() & universal
+        self._replace_extra_features(guaranteed | inherited)
         return True
+
+    @staticmethod
+    def _names_on_every_psm(all_metavalues) -> set:
+        """Metavalue names present on every PSM (intersection across rows)."""
+        common: Optional[set] = None
+        for mvs in all_metavalues:
+            names = {m.get("name") for m in mvs if isinstance(m, dict)}
+            common = names if common is None else (common & names)
+            if not common:
+                break
+        return common or set()
+
+    def _existing_extra_features(self) -> set:
+        sp_metavalues = self.search_params.get("sp_metavalues", []) or []
+        if not isinstance(sp_metavalues, list):
+            sp_metavalues = sp_metavalues.tolist()
+        for mv in sp_metavalues:
+            if isinstance(mv, dict) and mv.get("name") == "extra_features" and mv.get("value"):
+                return {n for n in str(mv["value"]).split(",") if n}
+        return set()
+
+    def _replace_extra_features(self, feature_names) -> None:
+        """Set ``extra_features`` to exactly ``feature_names``.
+
+        Unlike :meth:`_set_extra_features` this does NOT union with whatever was
+        already there, because in consensus mode the inherited list is the
+        priority engine's and is not guaranteed across the merged PSMs.
+        """
+        dropped = self._existing_extra_features() - set(feature_names)
+        if dropped:
+            logger.warning(
+                "Dropping inherited extra_features not present on every merged PSM: %s",
+                ", ".join(sorted(dropped)),
+            )
+        sp_metavalues = self.search_params.get("sp_metavalues", []) or []
+        if not isinstance(sp_metavalues, list):
+            sp_metavalues = sp_metavalues.tolist()
+        value = ",".join(sorted(feature_names))
+        for mv in sp_metavalues:
+            if isinstance(mv, dict) and mv.get("name") == "extra_features":
+                mv["value"] = value
+                break
+        else:
+            sp_metavalues.append(
+                {"name": "extra_features", "value": value, "value_type": "string"}
+            )
+        self.search_params["sp_metavalues"] = sp_metavalues
 
     def _repair_psmlist_scores(self, score_fallback: float) -> None:
         """Mirror the sentinel repair from ``_psms_df`` onto the ``PSMList``.

--- a/quantmsrescore/idparquet_reader.py
+++ b/quantmsrescore/idparquet_reader.py
@@ -573,8 +573,24 @@ class ParquetRescoringReader(ParquetReader):
             self._psms_df["score"] = fixed_scores
             self._repair_psmlist_scores(score_fallback)
 
+        # Advertise ONLY the features that actually got an imputation constant.
+        # A registry entry the data never provided (renamed metavalue key, or a
+        # primary score that lives in the `score` column rather than in
+        # psm_metavalues, as Comet's MS:1002257 does) cannot be written onto
+        # missing-engine PSMs, so declaring it would hand Percolator a name that
+        # is absent from some PSMs -- the defect this whole path exists to stop.
+        dropped = consensus_features.unconstrained_features(worst, orientation)
+        if dropped:
+            logger.warning(
+                "Consensus features declared by the registry but never observed in the "
+                "data, so they are NOT advertised to Percolator: %s. Check that these "
+                "metavalue names match what the engine emits.",
+                ", ".join(sorted(dropped)),
+            )
         self._set_extra_features(
-            consensus_features.union_feature_names(orientation, engine_labels=engines)
+            consensus_features.union_feature_names(
+                orientation, engine_labels=engines, worst=worst
+            )
         )
         return True
 

--- a/quantmsrescore/idparquet_reader.py
+++ b/quantmsrescore/idparquet_reader.py
@@ -636,7 +636,13 @@ class ParquetRescoringReader(ParquetReader):
         # advertises MS:1002053 that its own PSMs do not carry; unioning those
         # in would re-introduce engine-specific and outright absent names into
         # the very table this path exists to make complete.
-        universal = self._names_on_every_psm(new_metavalues)
+        # "Present on every PSM" includes the psms.parquet COLUMNS, not just the
+        # metavalues. Sage advertises a feature literally named `score`
+        # (verified on a real SageAdapter idparquet: extra_features =
+        # "score,SAGE:ln(-poisson),..."), which refers to the score column and
+        # is defined on every row once the inf sentinel has been repaired above.
+        # Intersecting against metavalues alone would silently discard it.
+        universal = self._names_on_every_psm(new_metavalues) | set(self._psms_df.columns)
         inherited = self._existing_extra_features() & universal
         self._replace_extra_features(guaranteed | inherited)
         return True

--- a/tests/test_consensus_features.py
+++ b/tests/test_consensus_features.py
@@ -551,6 +551,39 @@ class TestSageRegistryMatchesRealData:
         assert "ln(hyperscore)" not in CF.SAGE_FEATURE_ORIENTATION
         assert "hyperscore" not in CF.SAGE_FEATURE_ORIENTATION
 
+    def test_registry_matches_a_real_sageadapter_idparquet(self):
+        """Names verified by running SageAdapter for real (OpenMS
+        openms-tools-thirdparty 2026.07.02) on an MSV000085836 TMT mzML against
+        the decoy database from that run: 66 PSMs, 67 matched proteins
+        (55% target / 44% decoy). The psm_metavalues names it produced were:
+
+            DeltaMass, PTM, SAGE:ln(-poisson), SAGE:ln(delta_best),
+            SAGE:ln(delta_next), SAGE:ln(matched_intensity_pct),
+            SAGE:longest_b, SAGE:longest_y, SAGE:longest_y_pct,
+            SAGE:matched_peaks, SAGE:scored_candidates, protein_references,
+            spectrum_q
+
+        with score_type="ln(hyperscore)" and higher_score_better=True.
+
+        Two consequences are locked in below: every registered name really is
+        emitted, and ln(hyperscore) is a SCORE TYPE rather than a metavalue.
+        """
+        emitted_by_sageadapter = {
+            "SAGE:ln(-poisson)", "SAGE:ln(delta_best)", "SAGE:ln(delta_next)",
+            "SAGE:ln(matched_intensity_pct)", "SAGE:longest_b", "SAGE:longest_y",
+            "SAGE:longest_y_pct", "SAGE:matched_peaks", "SAGE:scored_candidates",
+        }
+        registered = set(CF.SAGE_FEATURE_ORIENTATION)
+        assert registered <= emitted_by_sageadapter, registered - emitted_by_sageadapter
+        assert emitted_by_sageadapter - registered == {"SAGE:ln(delta_best)"}
+
+    def test_spectrum_q_is_not_registered_as_a_feature(self):
+        # SageAdapter also emits `spectrum_q`, a q-value computed from
+        # target/decoy competition. Feeding a label-derived quantity to
+        # Percolator as a feature would be genuine leakage, so it must stay out
+        # of the registry.
+        assert not any("spectrum_q" in n for n in CF.SAGE_FEATURE_ORIENTATION)
+
     def test_deliberately_unregistered_names_are_documented_not_forgotten(self):
         emitted = self._sage_names()
         unregistered = emitted - set(CF.SAGE_FEATURE_ORIENTATION)

--- a/tests/test_consensus_features.py
+++ b/tests/test_consensus_features.py
@@ -182,7 +182,8 @@ class TestUnionFeatureNames:
 # A sage-only PSM carries sage markers + sage features.
 SAGE_ONLY = [_mv("SAGE:matched_peaks", "14", "int"), _mv("SAGE:longest_b", "6", "int"),
              _mv("SAGE:longest_y", "8", "int"), _mv("SAGE:ln(delta_next)", "1.4"),
-             _mv("ln(hyperscore)", "3.2"), _mv("SAGE:scored_candidates", "500", "int")]
+             _mv("ln(hyperscore)", "3.2"), _mv("SAGE:scored_candidates", "500", "int"),
+             _mv("SAGE:longest_y_pct", "0.7"), _mv("SAGE:ln(matched_intensity_pct)", "-0.3")]
 COMET_SAGE = ("Comet", "Sage")
 MSGF_SAGE = ("MS-GF+", "Sage")
 ALL_THREE = ("Comet", "MS-GF+", "Sage")
@@ -297,10 +298,10 @@ class TestSageIndicators:
         # The contract that makes the merge safe: whatever we declare in
         # extra_features must exist on EVERY merged PSM, whichever engine found it.
         orientation = CF.union_feature_orientation(ALL_THREE)
-        declared = CF.union_feature_names(orientation, engine_labels=ALL_THREE)
         worst = {}
         for mvs in (COMET_ONLY, MSGF_ONLY, SAGE_ONLY):
             CF.update_worst_case(mvs, worst, orientation)
+        declared = CF.union_feature_names(orientation, engine_labels=ALL_THREE, worst=worst)
         for mvs in (COMET_ONLY, MSGF_ONLY, SAGE_ONLY, COMET_ONLY + SAGE_ONLY):
             out = CF.build_consensus_features(
                 list(mvs), worst, orientation=orientation,
@@ -336,7 +337,7 @@ class TestOrientationDefaultsFollowEngineLabels:
         # NOTE: orientation deliberately omitted -- derived from engine_labels.
         out = CF.build_consensus_features(list(COMET_ONLY), worst, engine_labels=ALL_THREE)
         names = {m["name"] for m in out}
-        declared = CF.union_feature_names(engine_labels=ALL_THREE)
+        declared = CF.union_feature_names(engine_labels=ALL_THREE, worst=worst)
         assert declared.issubset(names), declared - names
 
     def test_presence_alone_also_derives_orientation(self):
@@ -347,7 +348,7 @@ class TestOrientationDefaultsFollowEngineLabels:
         presence = CF.detect_engines(COMET_ONLY, engine_labels=ALL_THREE)
         out = CF.build_consensus_features(list(COMET_ONLY), worst, presence=presence)
         names = {m["name"] for m in out}
-        assert CF.union_feature_names(engine_labels=ALL_THREE).issubset(names)
+        assert CF.union_feature_names(engine_labels=ALL_THREE, worst=worst).issubset(names)
 
     def test_no_labels_still_defaults_to_two_engine_union(self):
         worst = {}
@@ -355,7 +356,7 @@ class TestOrientationDefaultsFollowEngineLabels:
             CF.update_worst_case(mvs, worst)
         out = CF.build_consensus_features(list(COMET_ONLY), worst)
         names = {m["name"] for m in out}
-        assert CF.union_feature_names().issubset(names)
+        assert CF.union_feature_names(worst=worst).issubset(names)
         assert not any(n.startswith("SAGE:") for n in names)
 
 
@@ -413,3 +414,90 @@ class TestNonFiniteValuesAreRejected:
             value = float(item["value"])
             assert value == value, item                    # not NaN
             assert abs(value) != float("inf"), item        # not +/-inf
+
+
+# Comet metavalues as they ACTUALLY appear in
+# tests/test_data/..._comet.idparquet: MS:1002252/3/5/6/8/9 are present but
+# MS:1002257 (expectation) is NOT -- Comet keeps expect in the `score` column
+# (score_type=expect, higher_score_better=false). The registry nonetheless
+# declares MS:1002257, which is what made the fabricated 0.0 reachable.
+COMET_NO_EXPECT = [_mv("COMET:xcorr", "1.2"), _mv("COMET:deltaCn", "0.3"),
+                   _mv("COMET:spscore", "180"), _mv("MS:1002252", "1.2"),
+                   _mv("MS:1002258", "12"), _mv("MS:1002259", "40")]
+
+
+class TestDeclaredFeatureInvariant:
+    """Regression: a feature the data never provided must not be fabricated.
+
+    impute_union_features used ``worst.get(name, 0.0)``. The registry declares
+    Comet MS:1002257 (expectation value), but Comet stores its expectation in
+    the ``score`` column and emits no such metavalue -- verified against
+    tests/test_data/..._comet.idparquet, whose metavalue names include
+    MS:1002252/3/5/6/8/9 but NOT MS:1002257. The accumulator therefore never saw
+    it and every PSM was handed MS:1002257 = 0.0, the BEST possible value for a
+    lower-is-better expectation, while it was still advertised in
+    extra_features.
+    """
+
+    def test_feature_never_observed_is_not_fabricated(self):
+        worst = {}
+        CF.update_worst_case(COMET_NO_EXPECT, worst)     # no MS:1002257 anywhere
+        assert "MS:1002257" not in worst
+        out = CF.impute_union_features([], worst)
+        names = {m["name"] for m in out}
+        assert "MS:1002257" not in names
+
+    def test_feature_never_observed_is_not_advertised(self):
+        worst = {}
+        CF.update_worst_case(COMET_NO_EXPECT, worst)
+        declared = CF.union_feature_names(worst=worst)
+        assert "MS:1002257" not in declared
+
+    def test_observed_features_are_still_imputed_and_advertised(self):
+        worst = {}
+        CF.update_worst_case(COMET_NO_EXPECT, worst)
+        declared = CF.union_feature_names(worst=worst)
+        out = {m["name"] for m in CF.impute_union_features([], worst)}
+        for name in ("COMET:xcorr", "COMET:deltaCn", "COMET:spscore"):
+            assert name in declared
+            assert name in out
+
+    def test_indicators_always_advertised_even_with_no_constants(self):
+        # Indicators are computed per PSM (0/1), never imputed, so an empty
+        # accumulator must not strip them.
+        declared = CF.union_feature_names(worst={})
+        assert {"CONSENSUS:comet", "CONSENSUS:msgf"}.issubset(declared)
+
+    def test_unconstrained_reports_exactly_what_was_dropped(self):
+        worst = {}
+        CF.update_worst_case(COMET_NO_EXPECT, worst)
+        dropped = CF.unconstrained_features(worst)
+        assert "MS:1002257" in dropped
+        assert "COMET:xcorr" not in dropped
+        assert dropped == set(CF.UNION_FEATURE_ORIENTATION) - CF.constrained_features(worst)
+
+    def test_non_finite_only_feature_is_dropped_not_fabricated(self):
+        # Every observed value non-finite -> no usable constant -> must not be
+        # advertised, and must not fall back to 0.0.
+        worst = {}
+        CF.update_worst_case([_mv("COMET:xcorr", "inf")], worst)
+        CF.update_worst_case([_mv("COMET:xcorr", "nan")], worst)
+        assert "COMET:xcorr" not in CF.constrained_features(worst)
+        assert "COMET:xcorr" not in CF.union_feature_names(worst=worst)
+        assert "COMET:xcorr" not in {m["name"] for m in CF.impute_union_features([], worst)}
+
+    def test_declared_set_is_defined_on_every_psm_for_all_engines(self):
+        # The end-to-end contract, now with a registry entry that the data never
+        # supplies (MS:1002257) present in the orientation map.
+        orientation = CF.union_feature_orientation(ALL_THREE)
+        worst = {}
+        for mvs in (COMET_NO_EXPECT, MSGF_ONLY, SAGE_ONLY):
+            CF.update_worst_case(mvs, worst, orientation)
+        declared = CF.union_feature_names(orientation, engine_labels=ALL_THREE, worst=worst)
+        assert "MS:1002257" not in declared
+        for mvs in (COMET_NO_EXPECT, MSGF_ONLY, SAGE_ONLY, COMET_NO_EXPECT + SAGE_ONLY):
+            out = CF.build_consensus_features(
+                list(mvs), worst, orientation=orientation,
+                presence=CF.detect_engines(mvs, engine_labels=ALL_THREE))
+            names = {m["name"] for m in out}
+            assert declared.issubset(names), declared - names

--- a/tests/test_consensus_features.py
+++ b/tests/test_consensus_features.py
@@ -180,10 +180,16 @@ class TestUnionFeatureNames:
 # ---------------------------------------------------------------------------
 
 # A sage-only PSM carries sage markers + sage features.
+# Mirrors the metavalue names Sage actually emits, verified against
+# tests/test_data/..._sage_ms2rescore.idXML. Note ln(hyperscore) is absent --
+# Sage's primary score lives in the `score` column, not in metavalues -- and
+# SAGE:ln(delta_best) is present in the data but deliberately unregistered
+# (constant 0.0 at num_hits=1).
 SAGE_ONLY = [_mv("SAGE:matched_peaks", "14", "int"), _mv("SAGE:longest_b", "6", "int"),
              _mv("SAGE:longest_y", "8", "int"), _mv("SAGE:ln(delta_next)", "1.4"),
-             _mv("ln(hyperscore)", "3.2"), _mv("SAGE:scored_candidates", "500", "int"),
-             _mv("SAGE:longest_y_pct", "0.7"), _mv("SAGE:ln(matched_intensity_pct)", "-0.3")]
+             _mv("SAGE:ln(-poisson)", "2.1"), _mv("SAGE:scored_candidates", "500", "int"),
+             _mv("SAGE:longest_y_pct", "0.7"), _mv("SAGE:ln(matched_intensity_pct)", "-0.3"),
+             _mv("SAGE:ln(delta_best)", "0.0")]
 COMET_SAGE = ("Comet", "Sage")
 MSGF_SAGE = ("MS-GF+", "Sage")
 ALL_THREE = ("Comet", "MS-GF+", "Sage")
@@ -253,14 +259,19 @@ class TestSageImputation:
         assert worst["SAGE:matched_peaks"] == 5.0
 
     def test_unordered_feature_uses_midpoint_not_an_extreme(self):
-        # scored_candidates has no confidence ordering; imputing either extreme
-        # would assert a signal we have not measured.
-        orientation = CF.union_feature_orientation(("Sage",))
+        # No registry feature uses None today (scored_candidates was measured
+        # into the higher-is-better direction), but the mechanism must stay
+        # correct: a feature whose direction cannot be established is filled
+        # with a non-informative midpoint rather than a fabricated extreme.
+        orientation = {"UNORDERED:feature": None}
         worst = {}
         for v in ("100", "300", "500"):
-            CF.update_worst_case([_mv("SAGE:scored_candidates", v)], worst, orientation)
-        assert CF.SAGE_FEATURE_ORIENTATION["SAGE:scored_candidates"] is None
-        assert worst["SAGE:scored_candidates"] == 300.0  # midpoint of [100, 500]
+            CF.update_worst_case([_mv("UNORDERED:feature", v)], worst, orientation)
+        assert worst["UNORDERED:feature"] == 300.0  # midpoint of [100, 500]
+
+    def test_scored_candidates_is_higher_better_per_measurement(self):
+        # Measured on the Sage idXML fixture: target mean 193.0 vs decoy 113.7.
+        assert CF.SAGE_FEATURE_ORIENTATION["SAGE:scored_candidates"] is True
 
     def test_no_inf_or_nan_leaks_into_imputed_values(self):
         orientation = CF.union_feature_orientation(ALL_THREE)
@@ -395,10 +406,10 @@ class TestNonFiniteValuesAreRejected:
 
     def test_unordered_feature_range_ignores_non_finite(self):
         worst = {}
-        orientation = CF.union_feature_orientation(("Sage",))
+        orientation = {"UNORDERED:feature": None}
         for v in ("100", "inf", "500", "nan"):
-            CF.update_worst_case([_mv("SAGE:scored_candidates", v)], worst, orientation)
-        assert worst["SAGE:scored_candidates"] == 300.0  # midpoint of [100, 500]
+            CF.update_worst_case([_mv("UNORDERED:feature", v)], worst, orientation)
+        assert worst["UNORDERED:feature"] == 300.0  # midpoint of [100, 500]
 
     def test_non_finite_never_reaches_imputed_metavalues(self):
         orientation = CF.union_feature_orientation(ALL_THREE)
@@ -501,3 +512,48 @@ class TestDeclaredFeatureInvariant:
                 presence=CF.detect_engines(mvs, engine_labels=ALL_THREE))
             names = {m["name"] for m in out}
             assert declared.issubset(names), declared - names
+
+
+class TestSageRegistryMatchesRealData:
+    """Data-driven guard: the Sage registry must match the metavalue names Sage
+    actually emits, checked against the committed Sage idXML fixture.
+
+    This exists because the registry was originally written from the ms2rescore
+    feature table and was wrong in three ways: it missed SAGE:ln(-poisson),
+    it declared ln(hyperscore) which is not a metavalue at all (Sage's primary
+    score lives in the `score` column), and it guessed the direction of
+    SAGE:scored_candidates.
+    """
+
+    IDXML = ("tests/test_data/TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01"
+             "_sage_ms2rescore.idXML")
+
+    def _sage_names(self):
+        import os
+        import re
+        if not os.path.exists(self.IDXML):
+            import pytest
+            pytest.skip("Sage idXML fixture not available")
+        text = open(self.IDXML, encoding="utf-8", errors="ignore").read()
+        return {m for m in re.findall(r'name="(SAGE:[^"]+)"', text)}
+
+    def test_every_registered_sage_feature_exists_in_the_data(self):
+        emitted = self._sage_names()
+        registered = set(CF.SAGE_FEATURE_ORIENTATION)
+        assert registered <= emitted, registered - emitted
+
+    def test_hyperscore_is_not_registered_as_a_metavalue(self):
+        # Sage's primary score is score_type="hyperscore" in the `score` column.
+        # Note the idXML->idparquet conversion DROPS the primary score's
+        # UserParam entirely: the comet idXML carries MS:1002257 but the comet
+        # idparquet does not. Registering a primary score therefore declares a
+        # feature that cannot exist on any merged PSM.
+        assert "ln(hyperscore)" not in CF.SAGE_FEATURE_ORIENTATION
+        assert "hyperscore" not in CF.SAGE_FEATURE_ORIENTATION
+
+    def test_deliberately_unregistered_names_are_documented_not_forgotten(self):
+        emitted = self._sage_names()
+        unregistered = emitted - set(CF.SAGE_FEATURE_ORIENTATION)
+        # ln(delta_best) is constant 0.0 at num_hits=1, so it is left out on
+        # purpose. Anything else appearing here is drift that needs a decision.
+        assert unregistered == {"SAGE:ln(delta_best)"}, unregistered


### PR DESCRIPTION
Fixes the first `[high]` finding from the Codex adversarial review of #86: *"Missing worst constants default to best scores"*. Targets `dev`.

**I verified the finding against the real fixtures before fixing it — it is correct.**

## The defect

`impute_union_features` used `worst.get(name, 0.0)`. When no PSM in the run ever carried a declared feature, the accumulator had no constant, so every PSM was handed a fabricated `0.0` — the **best** possible value for every lower-is-better feature — while the name was still advertised in `extra_features`.

The concrete case Codex identified: the registry declares Comet `MS:1002257` (expectation value), but Comet keeps its expectation in the `score` column and emits no such metavalue. Confirmed against `tests/test_data/..._comet.idparquet`:

```
metavalue names: COMET:xcorr COMET:deltaCn COMET:spscore COMET:lnExpect ...
                 MS:1002252 MS:1002253 MS:1002255 MS:1002256 MS:1002258 MS:1002259
                 -- no MS:1002257
score_type=expect, higher_score_better=false
```

## Blast radius — measured, not assumed

Simulating a comet+msgf merge from both real fixtures:

```
registry declares 28 features
  observed in data : 27
  NEVER observed   : ['MS:1002257']
```

Because the fallback only fires when **no** PSM carries the feature, the result was a **constant** `0.0` column, not a skewed subset — a zero-variance feature Percolator weights at ~0. So the practical impact on the validated MSV000085836 run is expected to be negligible, and I'd rather say that plainly than overstate the severity.

The *mechanism*, though, is not negligible:

- **Sage is unvalidated.** Its 8 registry names come from the ms2rescore feature table and have never been checked against a Sage `idparquet` — no such fixture exists in the repo. The same path would silently fabricate all 8.
- **The all-non-finite case genuinely skews.** If every observed value of a feature is `inf`/`nan` (so #88 rejects them all), PSMs carrying it keep real non-finite values while the rest get `0.0` — a mixed population, not a constant.

## The fix

Establishes the invariant properly: **a feature is advertised only if the data provided a finite constant for it.**

- `impute_union_features` writes only constrained features; no fabrication
- `constrained_features()` / `unconstrained_features()` expose the split
- `union_feature_names(worst=...)` returns what is *actually* guaranteed. Indicators stay unconditional — they're computed per PSM (0/1) and never imputed
- the reader passes the accumulator and **logs what the registry claimed but the data never supplied**, so a renamed metavalue key becomes visible instead of silent

Verified end-to-end on real fixture metavalues: `MS:1002257` is no longer advertised or written, all 13 genuine Comet features are kept, and `declared − defined = NONE` for both a Comet PSM and an MS-GF+ PSM.

**No information is lost.** `COMET:lnExpect` is present in the data and is a monotone transform of the same quantity, so dropping `MS:1002257` costs nothing.

## Test contract change worth reviewing

Four pre-existing tests asserted the *nominal* registry set was imputed onto every PSM. That only held **because** unobserved features were fabricated — they were encoding the bug. They now pass the accumulator and assert against the constrained set. `SAGE_ONLY` is extended to a complete 8-feature Sage PSM so "constrained" reflects engine coverage rather than a fixture gap.

7 new tests (49 total), including a `COMET_NO_EXPECT` fixture mirroring the real parquet and the all-non-finite case.

## Not addressed here

The other five review findings remain open — notably the `[high]` on `extra_features` union-vs-replace (which overlaps this one), the Sage `higher_score_better` inversion, and the uncalibrated engine-source priors. The calibration one is a design question, not a patch.
