### PR TITLE
fix(consensus): do not truth-test parquet metavalue arrays (fixes multi-engine CI failure)

### DIFF
--- a/quantmsrescore/consensus_features.py
+++ b/quantmsrescore/consensus_features.py
@@ -292,6 +292,27 @@ def _to_list(psm_metavalues) -> List:
     return list(psm_metavalues)
 
 
+def as_metavalue_list(value) -> List:
+    """Normalise a metavalue container to a plain ``list``.
+
+    Values read back from parquet arrive as numpy arrays, and a numpy array has
+    no unambiguous truth value: ``value or []`` raises
+
+        ValueError: The truth value of an array with more than one element is
+        ambiguous. Use a.any() or a.all()
+
+    so the usual ``or []`` idiom is a trap here and must never be used on these
+    containers. This is the one place that decides how they are coerced.
+    """
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    if hasattr(value, "tolist"):
+        return value.tolist()
+    return list(value)
+
+
 def meta_map(psm_metavalues) -> Dict[str, object]:
     """Build a ``{name: value}`` map for one PSM's metavalues.
 

--- a/quantmsrescore/idparquet_reader.py
+++ b/quantmsrescore/idparquet_reader.py
@@ -659,9 +659,9 @@ class ParquetRescoringReader(ParquetReader):
         return common or set()
 
     def _existing_extra_features(self) -> set:
-        sp_metavalues = self.search_params.get("sp_metavalues", []) or []
-        if not isinstance(sp_metavalues, list):
-            sp_metavalues = sp_metavalues.tolist()
+        sp_metavalues = consensus_features.as_metavalue_list(
+            self.search_params.get("sp_metavalues")
+        )
         for mv in sp_metavalues:
             if isinstance(mv, dict) and mv.get("name") == "extra_features" and mv.get("value"):
                 return {n for n in str(mv["value"]).split(",") if n}
@@ -680,9 +680,9 @@ class ParquetRescoringReader(ParquetReader):
                 "Dropping inherited extra_features not present on every merged PSM: %s",
                 ", ".join(sorted(dropped)),
             )
-        sp_metavalues = self.search_params.get("sp_metavalues", []) or []
-        if not isinstance(sp_metavalues, list):
-            sp_metavalues = sp_metavalues.tolist()
+        sp_metavalues = consensus_features.as_metavalue_list(
+            self.search_params.get("sp_metavalues")
+        )
         value = ",".join(sorted(feature_names))
         for mv in sp_metavalues:
             if isinstance(mv, dict) and mv.get("name") == "extra_features":
@@ -762,11 +762,9 @@ class ParquetRescoringReader(ParquetReader):
 
     def _set_extra_features(self, feature_names) -> None:
         """Union ``feature_names`` into the ``extra_features`` search parameter."""
-        sp_metavalues = self.search_params.get("sp_metavalues", [])
-        if sp_metavalues is None:
-            sp_metavalues = []
-        elif not isinstance(sp_metavalues, list):
-            sp_metavalues = sp_metavalues.tolist()
+        sp_metavalues = consensus_features.as_metavalue_list(
+            self.search_params.get("sp_metavalues")
+        )
 
         existing: set = set()
         for mv in sp_metavalues:

--- a/tests/test_consensus_features.py
+++ b/tests/test_consensus_features.py
@@ -590,3 +590,61 @@ class TestSageRegistryMatchesRealData:
         # ln(delta_best) is constant 0.0 at num_hits=1, so it is left out on
         # purpose. Anything else appearing here is drift that needs a decision.
         assert unregistered == {"SAGE:ln(delta_best)"}, unregistered
+
+
+class TestMetavalueContainerNormalisation:
+    """Regression: parquet hands back numpy arrays, which have no unambiguous
+    truth value.
+
+    ``search_params["sp_metavalues"] or []`` raised
+
+        ValueError: The truth value of an array with more than one element is
+        ambiguous. Use a.any() or a.all()
+
+    which surfaced as test_psm_clean_multi_engine failing with exit_code 1 on a
+    real comet+msgf merge -- after the consensus features had already been
+    built, so the whole run was lost at the very last step.
+    """
+
+    class _FakeArray:
+        """Stands in for numpy's ndarray: iterable, but truth-testing raises."""
+
+        def __init__(self, items):
+            self._items = list(items)
+
+        def tolist(self):
+            return list(self._items)
+
+        def __iter__(self):
+            return iter(self._items)
+
+        def __len__(self):
+            return len(self._items)
+
+        def __bool__(self):
+            raise ValueError(
+                "The truth value of an array with more than one element is "
+                "ambiguous. Use a.any() or a.all()"
+            )
+
+    def test_array_like_is_normalised_without_truth_testing(self):
+        arr = self._FakeArray([_mv("COMET:xcorr", "1.2"), _mv("MS:1002258", "12")])
+        out = CF.as_metavalue_list(arr)
+        assert isinstance(out, list)
+        assert [m["name"] for m in out] == ["COMET:xcorr", "MS:1002258"]
+
+    def test_the_old_or_idiom_really_would_have_raised(self):
+        # Guards the premise: if this stops raising, the fake no longer models
+        # numpy and the regression test above is worthless.
+        import pytest
+        arr = self._FakeArray([_mv("a", "1"), _mv("b", "2")])
+        with pytest.raises(ValueError, match="truth value"):
+            arr or []
+
+    def test_none_and_plain_list_pass_through(self):
+        assert CF.as_metavalue_list(None) == []
+        items = [_mv("x", "1")]
+        assert CF.as_metavalue_list(items) is items
+
+    def test_empty_array_like_is_empty_list(self):
+        assert CF.as_metavalue_list(self._FakeArray([])) == []


### PR DESCRIPTION
Fixes the `Python package` CI failure on `main` ([run 30306734612](https://github.com/bigbio/quantms-rescoring/actions/runs/30306734612/job/90112682122)).

## The failure

```
FAILED tests/test_commands.py::test_psm_clean_multi_engine - AssertionError: assert 1 == 0
 + where 1 = <Result ValueError('The truth value of an array with more than
   one element is ambiguous. Use a.any() or a.all()')>.exit_code
```

## Cause — my own regression from #89

`search_params["sp_metavalues"]` comes back from parquet as a **numpy array**. The two helpers I added in #89 (`_existing_extra_features`, `_replace_extra_features`) normalised it with the ordinary `or []` idiom:

```python
sp_metavalues = self.search_params.get("sp_metavalues", []) or []
```

A numpy array has no unambiguous truth value, so `array or []` raises. The pre-existing `_set_extra_features` had deliberately avoided this with an explicit `None` / `isinstance` dance — the new code didn't inherit that care.

Two things made it slip through:

- It only reproduces on a **genuine multi-engine parquet**. The dependency-free unit tests in `test_consensus_features.py` pass plain lists, so all 55 stayed green.
- It fires at the **very end** of a real comet+msgf merge, *after* the consensus features are built — the log shows the new "declared but never observed: MS:1002257" warning immediately before the crash. So a full merge is computed and then thrown away at the last step.

## Fix

Adds `consensus_features.as_metavalue_list()` as the single place that decides how these containers are coerced, and routes **all three** call sites through it — including the original `_set_extra_features`, so there's one rule instead of two subtly different ones.

## Tests

4 regression tests using a fake array-like whose `__bool__` raises exactly as numpy's does. One of them asserts that the old `or []` idiom *really would* have raised — otherwise the fake could quietly stop modelling numpy and leave the regression test vacuous.

59 tests pass.

## Release note

`main` and the just-published **v0.0.22 are affected**: any multi-engine (`comet,msgf`, `*+sage`) run through `psm_feature_clean` will hit this. Single-engine runs never enter the path and are fine, and quantms defaults to `search_engines=comet` — but anyone running the two-engine configuration on 0.0.22 needs 0.0.23. Worth cutting that promptly.
