### PR TITLE
Release 0.0.23 — fix multi-engine numpy-array truthiness (#90)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "quantms-rescoring"
 description = "quantms-rescoring: Python scripts and helpers for the quantMS workflow"
 readme = "README.md"
 license = "MIT"
-version = "0.0.22"
+version = "0.0.23"
 authors = [
     "Yasset Perez-Riverol <ypriverol@gmail.com>",
     "Dai Chengxin <chengxin2024@126.com>",

--- a/quantmsrescore/__init__.py
+++ b/quantmsrescore/__init__.py
@@ -234,7 +234,7 @@ from warnings import filterwarnings
 # Suppress warnings about OPENMS_DATA_PATH
 filterwarnings("ignore", message=".*OPENMS_DATA_PATH.*", category=UserWarning)
 
-__version__ = "0.0.22"
+__version__ = "0.0.23"
 
 __all__ = [
     "configure_threading",

--- a/quantmsrescore/consensus_features.py
+++ b/quantmsrescore/consensus_features.py
@@ -292,6 +292,27 @@ def _to_list(psm_metavalues) -> List:
     return list(psm_metavalues)
 
 
+def as_metavalue_list(value) -> List:
+    """Normalise a metavalue container to a plain ``list``.
+
+    Values read back from parquet arrive as numpy arrays, and a numpy array has
+    no unambiguous truth value: ``value or []`` raises
+
+        ValueError: The truth value of an array with more than one element is
+        ambiguous. Use a.any() or a.all()
+
+    so the usual ``or []`` idiom is a trap here and must never be used on these
+    containers. This is the one place that decides how they are coerced.
+    """
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    if hasattr(value, "tolist"):
+        return value.tolist()
+    return list(value)
+
+
 def meta_map(psm_metavalues) -> Dict[str, object]:
     """Build a ``{name: value}`` map for one PSM's metavalues.
 

--- a/quantmsrescore/idparquet_reader.py
+++ b/quantmsrescore/idparquet_reader.py
@@ -659,9 +659,9 @@ class ParquetRescoringReader(ParquetReader):
         return common or set()
 
     def _existing_extra_features(self) -> set:
-        sp_metavalues = self.search_params.get("sp_metavalues", []) or []
-        if not isinstance(sp_metavalues, list):
-            sp_metavalues = sp_metavalues.tolist()
+        sp_metavalues = consensus_features.as_metavalue_list(
+            self.search_params.get("sp_metavalues")
+        )
         for mv in sp_metavalues:
             if isinstance(mv, dict) and mv.get("name") == "extra_features" and mv.get("value"):
                 return {n for n in str(mv["value"]).split(",") if n}
@@ -680,9 +680,9 @@ class ParquetRescoringReader(ParquetReader):
                 "Dropping inherited extra_features not present on every merged PSM: %s",
                 ", ".join(sorted(dropped)),
             )
-        sp_metavalues = self.search_params.get("sp_metavalues", []) or []
-        if not isinstance(sp_metavalues, list):
-            sp_metavalues = sp_metavalues.tolist()
+        sp_metavalues = consensus_features.as_metavalue_list(
+            self.search_params.get("sp_metavalues")
+        )
         value = ",".join(sorted(feature_names))
         for mv in sp_metavalues:
             if isinstance(mv, dict) and mv.get("name") == "extra_features":
@@ -762,11 +762,9 @@ class ParquetRescoringReader(ParquetReader):
 
     def _set_extra_features(self, feature_names) -> None:
         """Union ``feature_names`` into the ``extra_features`` search parameter."""
-        sp_metavalues = self.search_params.get("sp_metavalues", [])
-        if sp_metavalues is None:
-            sp_metavalues = []
-        elif not isinstance(sp_metavalues, list):
-            sp_metavalues = sp_metavalues.tolist()
+        sp_metavalues = consensus_features.as_metavalue_list(
+            self.search_params.get("sp_metavalues")
+        )
 
         existing: set = set()
         for mv in sp_metavalues:

--- a/tests/test_consensus_features.py
+++ b/tests/test_consensus_features.py
@@ -590,3 +590,61 @@ class TestSageRegistryMatchesRealData:
         # ln(delta_best) is constant 0.0 at num_hits=1, so it is left out on
         # purpose. Anything else appearing here is drift that needs a decision.
         assert unregistered == {"SAGE:ln(delta_best)"}, unregistered
+
+
+class TestMetavalueContainerNormalisation:
+    """Regression: parquet hands back numpy arrays, which have no unambiguous
+    truth value.
+
+    ``search_params["sp_metavalues"] or []`` raised
+
+        ValueError: The truth value of an array with more than one element is
+        ambiguous. Use a.any() or a.all()
+
+    which surfaced as test_psm_clean_multi_engine failing with exit_code 1 on a
+    real comet+msgf merge -- after the consensus features had already been
+    built, so the whole run was lost at the very last step.
+    """
+
+    class _FakeArray:
+        """Stands in for numpy's ndarray: iterable, but truth-testing raises."""
+
+        def __init__(self, items):
+            self._items = list(items)
+
+        def tolist(self):
+            return list(self._items)
+
+        def __iter__(self):
+            return iter(self._items)
+
+        def __len__(self):
+            return len(self._items)
+
+        def __bool__(self):
+            raise ValueError(
+                "The truth value of an array with more than one element is "
+                "ambiguous. Use a.any() or a.all()"
+            )
+
+    def test_array_like_is_normalised_without_truth_testing(self):
+        arr = self._FakeArray([_mv("COMET:xcorr", "1.2"), _mv("MS:1002258", "12")])
+        out = CF.as_metavalue_list(arr)
+        assert isinstance(out, list)
+        assert [m["name"] for m in out] == ["COMET:xcorr", "MS:1002258"]
+
+    def test_the_old_or_idiom_really_would_have_raised(self):
+        # Guards the premise: if this stops raising, the fake no longer models
+        # numpy and the regression test above is worthless.
+        import pytest
+        arr = self._FakeArray([_mv("a", "1"), _mv("b", "2")])
+        with pytest.raises(ValueError, match="truth value"):
+            arr or []
+
+    def test_none_and_plain_list_pass_through(self):
+        assert CF.as_metavalue_list(None) == []
+        items = [_mv("x", "1")]
+        assert CF.as_metavalue_list(items) is items
+
+    def test_empty_array_like_is_empty_list(self):
+        assert CF.as_metavalue_list(self._FakeArray([])) == []


### PR DESCRIPTION
Release PR for **0.0.23**. Carries the #90 fix from `dev` to `main` and bumps the version in both `pyproject.toml` and `quantmsrescore/__init__.py`.

## Why 0.0.23 is needed urgently

0.0.22 is **broken for every multi-engine run**. `search_params["sp_metavalues"]` is a numpy array read back from parquet, and two helpers introduced in #89 truth-tested it with `or []`:

```
ValueError: The truth value of an array with more than one element is
ambiguous. Use a.any() or a.all()
```

It fires at the *end* of a `comet,msgf` (or `*+sage`) merge, after the consensus features are already built — so the whole run is wasted. #90 fixed it (`as_metavalue_list`) and merged to `dev`; this PR ships it.

Single-engine runs are unaffected (they never enter the consensus path), and quantms defaults to `search_engines=comet`.

## This PR is also the first real test of the fix

**The `Python package` / `Python application` workflows only run on push/PR to `main`** — not on `dev`-targeted PRs. Every fix in this release (#85, #87, #88, #89, #90) went into `dev` via a `dev`-targeted PR, so the full pytest suite (including `test_psm_clean_multi_engine`, which needs pyopenms and a real multi-engine parquet) **never ran against them until now**. That is exactly how the 0.0.22 regression reached a release.

So the gate for tagging 0.0.23 is simple: **`build (3.11)` on this PR must be green, and `test_psm_clean_multi_engine` in particular must pass.** I could not run that test locally (no pyopenms), so CI here is the real validation.

## Contents since 0.0.22

- #90 — do not truth-test parquet metavalue arrays (the regression fix)

Everything else (#85 SAGE generalisation, #87–#89 review fixes, the real-SageAdapter registry validation) is already on `main` via the 0.0.22 release; this PR adds only #90 plus the version bump.

## Follow-up (not in this PR)

- Add an integration test over a committed multi-engine parquet fixture so this class of bug is caught by unit CI, not only by the `dev→main` gate.
- Consider running the test workflow on `dev` pushes too, so `dev`-targeted fixes are validated before they accumulate.
