### PR TITLE
Release 0.0.24 — get_default_scores None-guard (fixes fine_tuning crash)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "quantms-rescoring"
 description = "quantms-rescoring: Python scripts and helpers for the quantMS workflow"
 readme = "README.md"
 license = "MIT"
-version = "0.0.22"
+version = "0.0.23"
 authors = [
     "Yasset Perez-Riverol <ypriverol@gmail.com>",
     "Dai Chengxin <chengxin2024@126.com>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "quantms-rescoring"
 description = "quantms-rescoring: Python scripts and helpers for the quantMS workflow"
 readme = "README.md"
 license = "MIT"
-version = "0.0.23"
+version = "0.0.24"
 authors = [
     "Yasset Perez-Riverol <ypriverol@gmail.com>",
     "Dai Chengxin <chengxin2024@126.com>",

--- a/quantmsrescore/__init__.py
+++ b/quantmsrescore/__init__.py
@@ -234,7 +234,7 @@ from warnings import filterwarnings
 # Suppress warnings about OPENMS_DATA_PATH
 filterwarnings("ignore", message=".*OPENMS_DATA_PATH.*", category=UserWarning)
 
-__version__ = "0.0.22"
+__version__ = "0.0.23"
 
 __all__ = [
     "configure_threading",

--- a/quantmsrescore/__init__.py
+++ b/quantmsrescore/__init__.py
@@ -234,7 +234,7 @@ from warnings import filterwarnings
 # Suppress warnings about OPENMS_DATA_PATH
 filterwarnings("ignore", message=".*OPENMS_DATA_PATH.*", category=UserWarning)
 
-__version__ = "0.0.23"
+__version__ = "0.0.24"
 
 __all__ = [
     "configure_threading",

--- a/quantmsrescore/idparquet_reader.py
+++ b/quantmsrescore/idparquet_reader.py
@@ -786,24 +786,42 @@ class ParquetRescoringReader(ParquetReader):
             )
         self.search_params["sp_metavalues"] = sp_metavalues
 
+    @staticmethod
+    def _as_float(value):
+        """Best-effort float, or None. ``get_meta_features`` returns None when a
+        PSM lacks the requested metavalue, and ``float(None)`` raises; a single
+        such PSM must not kill the whole run."""
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
     def get_default_scores(self, search_params, psm_metavalues, record):
+        """Accumulate the per-engine worst primary score across PSMs.
+
+        A PSM whose primary score is missing (e.g. a Comet PSM without
+        ``MS:1002252`` xcorr, seen with ms2rescore-annotated phospho/ETD data)
+        simply does not contribute to the min/max rather than crashing. If EVERY
+        PSM of an engine lacks the value the seed (inf / -inf) is left untouched,
+        which :meth:`_sentinel_score_fallback` already handles.
+        """
         if "MS-GF+" in search_params["search_engine"]:
-            msgf_RawScore = float(self.get_meta_features(psm_metavalues, "MS:1002049"))
-            msgf_EValue = float(record["score"])
-            if msgf_RawScore < self.min_msgf_RawScore:
+            msgf_RawScore = self._as_float(self.get_meta_features(psm_metavalues, "MS:1002049"))
+            msgf_EValue = self._as_float(record["score"])
+            if msgf_RawScore is not None and msgf_RawScore < self.min_msgf_RawScore:
                 self.min_msgf_RawScore = msgf_RawScore
-            if msgf_EValue > self.max_msgf_EValue:
+            if msgf_EValue is not None and msgf_EValue > self.max_msgf_EValue:
                 self.max_msgf_EValue = msgf_EValue
         elif "Sage" in search_params["search_engine"]:
-            sage_hyperscore = float(record["score"])
-            if sage_hyperscore < self.min_sage_hyperscore:
+            sage_hyperscore = self._as_float(record["score"])
+            if sage_hyperscore is not None and sage_hyperscore < self.min_sage_hyperscore:
                 self.min_sage_hyperscore = sage_hyperscore
         else:
-            comet_xcorr = float(self.get_meta_features(psm_metavalues, "MS:1002252"))
-            comet_expectation_value = float(record["score"])
-            if comet_xcorr < self.min_comet_xcorr:
+            comet_xcorr = self._as_float(self.get_meta_features(psm_metavalues, "MS:1002252"))
+            comet_expectation_value = self._as_float(record["score"])
+            if comet_xcorr is not None and comet_xcorr < self.min_comet_xcorr:
                 self.min_comet_xcorr = comet_xcorr
-            if comet_expectation_value > self.max_comet_expectation_value:
+            if comet_expectation_value is not None and comet_expectation_value > self.max_comet_expectation_value:
                 self.max_comet_expectation_value = comet_expectation_value
 
     @staticmethod

--- a/quantmsrescore/idparquet_reader.py
+++ b/quantmsrescore/idparquet_reader.py
@@ -751,7 +751,12 @@ class ParquetRescoringReader(ParquetReader):
         """
         if self._psms_df is None or "score" not in self._psms_df:
             return 0.0
-        finite = self._psms_df["score"][np.isfinite(self._psms_df["score"])]
+        # Coerce first: the score column can be object-dtype (e.g. a null score
+        # arrives as Python None), and np.isfinite raises on object arrays even
+        # without a None present. pd.to_numeric(errors="coerce") turns anything
+        # non-numeric into NaN, which dropna() then removes.
+        scores = pd.to_numeric(self._psms_df["score"], errors="coerce")
+        finite = scores[np.isfinite(scores)]
         if finite.empty:
             logger.warning(
                 "No finite PSM score available to replace the merge sentinel; "

--- a/tests/test_get_default_scores.py
+++ b/tests/test_get_default_scores.py
@@ -1,0 +1,100 @@
+"""Regression tests for ParquetRescoringReader.get_default_scores.
+
+get_default_scores accumulates the per-engine worst primary score across PSMs.
+It did `float(get_meta_features(psm_metavalues, "MS:1002252"))` for Comet, but
+get_meta_features returns None when a PSM lacks that metavalue (seen with
+ms2rescore-annotated phospho/ETD data), and float(None) raises TypeError,
+killing the whole run at the SNR spectrum2feature step (idparquet_reader.py:802,
+test_dda_id_fine_tuning). A single PSM missing its primary score must not crash.
+
+Constructed via __new__ to avoid the pyopenms/mzML dependency of __init__.
+"""
+
+import math
+import numpy as np
+import pytest
+
+from quantmsrescore.idparquet_reader import ParquetRescoringReader
+
+
+def _reader():
+    r = ParquetRescoringReader.__new__(ParquetRescoringReader)
+    r.min_msgf_RawScore = np.inf
+    r.max_msgf_EValue = -np.inf
+    r.max_comet_expectation_value = -np.inf
+    r.min_comet_xcorr = np.inf
+    r.min_sage_hyperscore = np.inf
+    return r
+
+
+def _mv(name, value):
+    return {"name": name, "value": value}
+
+
+class TestAsFloat:
+    def test_none_returns_none_not_raises(self):
+        assert ParquetRescoringReader._as_float(None) is None
+
+    def test_numbers_and_strings(self):
+        assert ParquetRescoringReader._as_float("1.5") == 1.5
+        assert ParquetRescoringReader._as_float(2) == 2.0
+
+    def test_garbage_returns_none(self):
+        assert ParquetRescoringReader._as_float("n/a") is None
+
+
+class TestCometMissingXcorr:
+    def test_missing_ms1002252_does_not_crash(self):
+        r = _reader()
+        # a Comet PSM WITHOUT MS:1002252 -> get_meta_features returns None
+        r.get_default_scores(
+            {"search_engine": "Comet"},
+            [_mv("COMET:deltaCn", "0.3")],   # no MS:1002252
+            {"score": "0.01"},
+        )
+        # xcorr contributes nothing; seed stays inf; expectation still tracked
+        assert math.isinf(r.min_comet_xcorr)
+        assert r.max_comet_expectation_value == 0.01
+
+    def test_present_xcorr_is_tracked(self):
+        r = _reader()
+        r.get_default_scores(
+            {"search_engine": "Comet"},
+            [_mv("MS:1002252", "1.8")],
+            {"score": "0.02"},
+        )
+        assert r.min_comet_xcorr == 1.8
+        assert r.max_comet_expectation_value == 0.02
+
+    def test_mixed_psms_take_the_worst_of_the_present_ones(self):
+        r = _reader()
+        for mv, score in (([_mv("MS:1002252", "2.0")], "0.01"),
+                          ([_mv("COMET:deltaCn", "0.1")], "0.5"),   # missing xcorr
+                          ([_mv("MS:1002252", "1.2")], "0.2")):
+            r.get_default_scores({"search_engine": "Comet"}, mv, {"score": score})
+        assert r.min_comet_xcorr == 1.2       # min over the two present values
+        assert r.max_comet_expectation_value == 0.5
+
+
+class TestMsgfMissingRawScore:
+    def test_missing_ms1002049_does_not_crash(self):
+        r = _reader()
+        r.get_default_scores(
+            {"search_engine": "MS-GF+"},
+            [_mv("ExplainedIonCurrentRatio", "0.4")],   # no MS:1002049
+            {"score": "1e-10"},
+        )
+        assert math.isinf(r.min_msgf_RawScore)
+        assert r.max_msgf_EValue == 1e-10
+
+
+class TestSage:
+    def test_sage_uses_score_column(self):
+        r = _reader()
+        r.get_default_scores({"search_engine": "Sage"}, [], {"score": "3.2"})
+        assert r.min_sage_hyperscore == 3.2
+
+    def test_sage_none_score_does_not_crash(self):
+        r = _reader()
+        r.get_default_scores({"search_engine": "Sage"}, [], {"score": None})
+        assert math.isinf(r.min_sage_hyperscore)

--- a/tests/test_get_default_scores.py
+++ b/tests/test_get_default_scores.py
@@ -98,3 +98,42 @@ class TestSage:
         r = _reader()
         r.get_default_scores({"search_engine": "Sage"}, [], {"score": None})
         assert math.isinf(r.min_sage_hyperscore)
+
+
+import pandas as pd
+
+
+class TestWorstObservedScore:
+    """Regression: _worst_observed_score must not crash on an object-dtype score
+    column. np.isfinite raises on object arrays (even without a None), and a
+    null score arrives as Python None -> object dtype. This is the last-resort
+    sentinel fallback, so a rare degenerate merge must degrade, not crash.
+    """
+
+    def _reader_with_scores(self, values, high_score_better):
+        r = ParquetRescoringReader.__new__(ParquetRescoringReader)
+        r._psms_df = pd.DataFrame({"score": values})
+        r.high_score_better = high_score_better
+        return r
+
+    def test_object_dtype_with_none_lower_is_better(self):
+        r = self._reader_with_scores(pd.Series([0.01, float("inf"), None, 0.5], dtype=object), False)
+        assert r._worst_observed_score() == 0.5   # worst (max) of finite, not a crash
+
+    def test_object_dtype_with_none_higher_is_better(self):
+        r = self._reader_with_scores(pd.Series([5.0, float("inf"), None, 2.0], dtype=object), True)
+        assert r._worst_observed_score() == 2.0   # worst (min) of finite
+
+    def test_all_sentinel_or_null_returns_zero(self):
+        r = self._reader_with_scores(pd.Series([float("inf"), None], dtype=object), False)
+        assert r._worst_observed_score() == 0.0
+
+    def test_plain_float_column_still_works(self):
+        r = self._reader_with_scores([0.01, float("inf"), 0.5], False)
+        assert r._worst_observed_score() == 0.5
+
+    def test_no_score_column_returns_zero(self):
+        r = ParquetRescoringReader.__new__(ParquetRescoringReader)
+        r._psms_df = pd.DataFrame({"other": [1, 2]})
+        r.high_score_better = False
+        assert r._worst_observed_score() == 0.0


### PR DESCRIPTION
Ships #93: `get_default_scores` no longer crashes with `float(None)` when a PSM lacks its engine's primary metavalue (Comet `MS:1002252` on ms2rescore phospho/ETD data). This is what fails quantms `test_dda_id_fine_tuning` on the 0.0.23 container — the last red job after 0.0.23 fixed the other 13.

Gate: `build (3.11)` here runs the rescoring unit suite including the new `test_get_default_scores.py`. The end-to-end fine_tuning validation happens in quantms CI once #719 is re-pinned to 0.0.24.

Pre-existing latent bug (not from the consensus work); previously masked on 0.0.22 by the `or []` crash that landed earlier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved score handling when values are missing, invalid, or unavailable.
  * Prevented rescoring errors caused by absent score fields.
  * Preserved correct fallback behavior when no valid scores are available.

* **Tests**
  * Added coverage for missing, null, numeric, and invalid score values.

* **Chores**
  * Updated the package version to 0.0.24.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->