### PR TITLE
fix(reader): harden _worst_observed_score against object-dtype score column

### DIFF
--- a/quantmsrescore/idparquet_reader.py
+++ b/quantmsrescore/idparquet_reader.py
@@ -751,7 +751,12 @@ class ParquetRescoringReader(ParquetReader):
         """
         if self._psms_df is None or "score" not in self._psms_df:
             return 0.0
-        finite = self._psms_df["score"][np.isfinite(self._psms_df["score"])]
+        # Coerce first: the score column can be object-dtype (e.g. a null score
+        # arrives as Python None), and np.isfinite raises on object arrays even
+        # without a None present. pd.to_numeric(errors="coerce") turns anything
+        # non-numeric into NaN, which dropna() then removes.
+        scores = pd.to_numeric(self._psms_df["score"], errors="coerce")
+        finite = scores[np.isfinite(scores)]
         if finite.empty:
             logger.warning(
                 "No finite PSM score available to replace the merge sentinel; "

--- a/tests/test_get_default_scores.py
+++ b/tests/test_get_default_scores.py
@@ -98,3 +98,42 @@ class TestSage:
         r = _reader()
         r.get_default_scores({"search_engine": "Sage"}, [], {"score": None})
         assert math.isinf(r.min_sage_hyperscore)
+
+
+import pandas as pd
+
+
+class TestWorstObservedScore:
+    """Regression: _worst_observed_score must not crash on an object-dtype score
+    column. np.isfinite raises on object arrays (even without a None), and a
+    null score arrives as Python None -> object dtype. This is the last-resort
+    sentinel fallback, so a rare degenerate merge must degrade, not crash.
+    """
+
+    def _reader_with_scores(self, values, high_score_better):
+        r = ParquetRescoringReader.__new__(ParquetRescoringReader)
+        r._psms_df = pd.DataFrame({"score": values})
+        r.high_score_better = high_score_better
+        return r
+
+    def test_object_dtype_with_none_lower_is_better(self):
+        r = self._reader_with_scores(pd.Series([0.01, float("inf"), None, 0.5], dtype=object), False)
+        assert r._worst_observed_score() == 0.5   # worst (max) of finite, not a crash
+
+    def test_object_dtype_with_none_higher_is_better(self):
+        r = self._reader_with_scores(pd.Series([5.0, float("inf"), None, 2.0], dtype=object), True)
+        assert r._worst_observed_score() == 2.0   # worst (min) of finite
+
+    def test_all_sentinel_or_null_returns_zero(self):
+        r = self._reader_with_scores(pd.Series([float("inf"), None], dtype=object), False)
+        assert r._worst_observed_score() == 0.0
+
+    def test_plain_float_column_still_works(self):
+        r = self._reader_with_scores([0.01, float("inf"), 0.5], False)
+        assert r._worst_observed_score() == 0.5
+
+    def test_no_score_column_returns_zero(self):
+        r = ParquetRescoringReader.__new__(ParquetRescoringReader)
+        r._psms_df = pd.DataFrame({"other": [1, 2]})
+        r.high_score_better = False
+        assert r._worst_observed_score() == 0.0


### PR DESCRIPTION
Deep-review finding, same None/dtype class as #90/#93. `np.isfinite` raises on an object-dtype array (even without a None), and a null PSM score arrives as Python None → object dtype. `_worst_observed_score` did `np.isfinite(self._psms_df['score'])` directly, so the last-resort sentinel fallback crashed instead of degrading. Now coerces with `pd.to_numeric(errors='coerce')` first. Rare path (no configured engine has a finite reader stat and its primary was never accumulated), but recoverable → shouldn't hard-crash. +5 tests.