### PR TITLE
chore: sync dev version to 0.0.24

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "quantms-rescoring"
 description = "quantms-rescoring: Python scripts and helpers for the quantMS workflow"
 readme = "README.md"
 license = "MIT"
-version = "0.0.23"
+version = "0.0.24"
 authors = [
     "Yasset Perez-Riverol <ypriverol@gmail.com>",
     "Dai Chengxin <chengxin2024@126.com>",

--- a/quantmsrescore/__init__.py
+++ b/quantmsrescore/__init__.py
@@ -234,7 +234,7 @@ from warnings import filterwarnings
 # Suppress warnings about OPENMS_DATA_PATH
 filterwarnings("ignore", message=".*OPENMS_DATA_PATH.*", category=UserWarning)
 
-__version__ = "0.0.23"
+__version__ = "0.0.24"
 
 __all__ = [
     "configure_threading",


### PR DESCRIPTION
Bumps dev to 0.0.24 to match released main; keeps dev at/ahead of the release line.